### PR TITLE
Bugfix: switch was not passed to gams when restarting

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '235968'
+ValidationKey: '255710'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ type: software
 title: |-
   brick: Building sector model with heterogeuous renovation and construction of
       the stock
-version: 0.1.2
-date-released: '2023-11-03'
+version: 0.1.3
+date-released: '2023-11-09'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: brick
 Title: Building sector model with heterogeuous renovation and construction of
     the stock
-Version: 0.1.2
-Date: 2023-11-03
+Version: 0.1.3
+Date: 2023-11-09
 Authors@R:
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/R/restartModel.R
+++ b/R/restartModel.R
@@ -90,7 +90,8 @@ restartModel <- function(path = NULL,
 
   runGams(path,
           cfg[["gamsOptions"]],
-          c(cfg[["switches"]], cfg[c("solverLP", "solverNLP", "solverQCP")]),
+          c(cfg[["switches"]], cfg[c("solverLP", "solverNLP", "solverQCP",
+                                     "ignoreShell")]),
           gamsCall = cfg[["gamsCall"]])
 
   plotSummary(path, NULL, showHistStock = cfg[["switches"]][["RUNTYPE"]] %in% c("calibration", "matching") ||

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# Building sector model with heterogeuous renovation and construction of
-    the stock
+# Building sector model with heterogeuous renovation and construction of the stock
 
-R package **brick**, version **0.1.2**
+R package **brick**, version **0.1.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/brick)](https://cran.r-project.org/package=brick)  [![R build status](https://github.com/pik-piam/brick/workflows/check/badge.svg)](https://github.com/pik-piam/brick/actions) [![codecov](https://codecov.io/gh/pik-piam/brick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/brick) 
 
@@ -49,7 +48,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **brick** in publications use:
 
-Hasse R (2023). _brick: Building sector model with heterogeuous renovation and construction of the stock_. R package version 0.1.2, <https://github.com/pik-piam/brick>.
+Hasse R (2023). _brick: Building sector model with heterogeuous renovation and construction of the stock_. R package version 0.1.3, <https://github.com/pik-piam/brick>.
 
 A BibTeX entry for LaTeX users is
 
@@ -59,7 +58,7 @@ A BibTeX entry for LaTeX users is
 the stock},
   author = {Robin Hasse},
   year = {2023},
-  note = {R package version 0.1.2},
+  note = {R package version 0.1.3},
   url = {https://github.com/pik-piam/brick},
 }
 ```


### PR DESCRIPTION
I forgot to also pass `ignoreShell` when restarting a scenario. This is now fixed.