### PR TITLE
Bugfix: always have input folder

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '794920'
+ValidationKey: '814834'
 AutocreateReadme: no
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 .RData
 .Ruserdata
 output/*
-inst/input/*

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ type: software
 title: |-
   brick: Building sector model with heterogeneous renovation and construction of
       the stock
-version: 0.4.0
-date-released: '2024-05-30'
+version: 0.4.1
+date-released: '2024-05-31'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of
     the stock
-Version: 0.4.0
-Date: 2024-05-30
+Version: 0.4.1
+Date: 2024-05-31
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),
@@ -33,7 +33,7 @@ Imports:
     ggplot2,
     gamstransfer (>= 3.0.1),
     gms (>= 0.26.0),
-    piamutils (>= 0.0.7),
+    piamutils (>= 0.0.10),
     pkgload,
     purrr,
     quitte,

--- a/R/brick.file.R
+++ b/R/brick.file.R
@@ -4,20 +4,15 @@
 #' the package via \code{devtools::load_all("path/to/brick")}
 #'
 #' @param ... character vectors, specifying subdirectory and files within brick
+#' @param mustWork if TRUE, an error is given if there are no matching files
 #' @returns A character vector of positive length, containing the file paths
-#'   that matched \code{...}, or the empty string, \code{""}, if none matched
-#'   (unless \code{mustWork = TRUE}).
-#'   files.
+#'   that matched \code{...} in BRICK.
 #'
 #' @author Robin Hasse
 #'
 #' @importFrom piamutils getSystemFile
 #' @export
 
-brick.file <- function(...) {
-  path <- getSystemFile(file.path(...), package = "brick")
-  if (!file.exists(path)) {
-    stop("Cannot find this BRICK file: ", path)
-  }
-  return(path)
+brick.file <- function(..., mustWork = TRUE) {
+  getSystemFile(..., package = "brick", mustWork = mustWork)
 }

--- a/R/createParameters.R
+++ b/R/createParameters.R
@@ -74,7 +74,7 @@ createParameters <- function(m, config, inputDir) {
               by = c("bs", "hs", "reg", "typ", "ttot"))
   p_specCostConIntang <- p_specCostCon %>%
     filter(.data[["cost"]] == "intangible") %>%
-    addAssump(brick.file("assump/costIntangCon.csv"))
+    addAssump(brick.file("assump", "costIntangCon.csv"))
   p_specCostCon <- rbind(p_specCostConTang, p_specCostConIntang)
   p_specCostCon <- m$addParameter(
     name = "p_specCostCon",
@@ -99,7 +99,7 @@ createParameters <- function(m, config, inputDir) {
               by = c("ttot", "reg", "bs", "hs", "bsr", "hsr", "typ", "vin"))
   p_specCostRenIntang <- p_specCostRen %>%
     filter(.data[["cost"]] == "intangible") %>%
-    addAssump(brick.file("assump/costIntangRen.csv"))
+    addAssump(brick.file("assump", "costIntangRen.csv"))
   p_specCostRen <- rbind(p_specCostRenTang, p_specCostRenIntang)
   p_specCostRen <- m$addParameter(
     name = "p_specCostRen",

--- a/R/loadMadratData.R
+++ b/R/loadMadratData.R
@@ -25,7 +25,7 @@ loadMadratData <- function(config) {
   # Identify madrat tgz files --------------------------------------------------
 
   # find package directory
-  inputDir <- brick.file("input")
+  inputDir <- brick.file("input", mustWork = FALSE)
 
   # where are the old files from?
   sourceFiles <- file.path(inputDir, "source_files.log")

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Building sector model with heterogeneous renovation and construction of the stock
 
-R package **brick**, version **0.4.0**
+R package **brick**, version **0.4.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/brick)](https://cran.r-project.org/package=brick)  [![R build status](https://github.com/pik-piam/brick/workflows/check/badge.svg)](https://github.com/pik-piam/brick/actions) [![codecov](https://codecov.io/gh/pik-piam/brick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/brick) 
 
@@ -50,7 +50,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **brick** in publications use:
 
-Hasse R, Rosemann R (2024). _brick: Building sector model with heterogeneous renovation and construction of the stock_. R package version 0.4.0, <https://github.com/pik-piam/brick>.
+Hasse R, Rosemann R (2024). _brick: Building sector model with heterogeneous renovation and construction of the stock_. R package version 0.4.1, <https://github.com/pik-piam/brick>.
 
 A BibTeX entry for LaTeX users is
 
@@ -60,7 +60,7 @@ A BibTeX entry for LaTeX users is
 the stock},
   author = {Robin Hasse and Ricarda Rosemann},
   year = {2024},
-  note = {R package version 0.4.0},
+  note = {R package version 0.4.1},
   url = {https://github.com/pik-piam/brick},
 }
 ```

--- a/inst/input/.gitignore
+++ b/inst/input/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/man/brick.file.Rd
+++ b/man/brick.file.Rd
@@ -4,16 +4,16 @@
 \alias{brick.file}
 \title{Find the full file names of files in BRICK}
 \usage{
-brick.file(...)
+brick.file(..., mustWork = TRUE)
 }
 \arguments{
 \item{...}{character vectors, specifying subdirectory and files within brick}
+
+\item{mustWork}{if TRUE, an error is given if there are no matching files}
 }
 \value{
 A character vector of positive length, containing the file paths
-  that matched \code{...}, or the empty string, \code{""}, if none matched
-  (unless \code{mustWork = TRUE}).
-  files.
+  that matched \code{...} in BRICK.
 }
 \description{
 This is meant to work with the installed package BRICK but also when loading


### PR DESCRIPTION
I committed the folder `inst/input` because it missing can lead to an error with fresh installations.