### PR TITLE
Enable custom cpu

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '875688'
+ValidationKey: '875908'
 AutocreateReadme: no
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '855485'
+ValidationKey: '875556'
 AutocreateReadme: no
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '875556'
+ValidationKey: '875688'
 AutocreateReadme: no
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ type: software
 title: |-
   brick: Building sector model with heterogeneous renovation and construction of
       the stock
-version: 0.4.3
-date-released: '2024-06-21'
+version: 0.4.4
+date-released: '2024-06-25'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ title: |-
   brick: Building sector model with heterogeneous renovation and construction of
       the stock
 version: 0.4.4
-date-released: '2024-06-25'
+date-released: '2024-06-28'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).
@@ -19,11 +19,11 @@ authors:
 - family-names: Hasse
   given-names: Robin
   email: robin.hasse@pik-potsdam.de
-  orcid: 0000-0003-1818-3186
+  orcid: https://orcid.org/0000-0003-1818-3186
 - family-names: Rosemann
   given-names: Ricarda
   email: ricarda.rosemann@pik-potsdam.de
-  orcid: 0009-0006-5939-3197
+  orcid: https://orcid.org/0009-0006-5939-3197
 license: LGPL-3.0
 repository-code: https://github.com/pik-piam/brick
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ title: |-
   brick: Building sector model with heterogeneous renovation and construction of
       the stock
 version: 0.4.4
-date-released: '2024-06-28'
+date-released: '2024-07-03'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Package: brick
 Title: Building sector model with heterogeneous renovation and construction of
     the stock
 Version: 0.4.4
-Date: 2024-06-25
+Date: 2024-06-28
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Package: brick
 Title: Building sector model with heterogeneous renovation and construction of
     the stock
 Version: 0.4.4
-Date: 2024-06-28
+Date: 2024-07-03
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),
@@ -47,4 +47,4 @@ Suggests:
     devtools,
     testthat
 Encoding: UTF-8
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of
     the stock
-Version: 0.4.3
-Date: 2024-06-21
+Version: 0.4.4
+Date: 2024-06-25
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/R/initModel.R
+++ b/R/initModel.R
@@ -58,11 +58,6 @@ initModel <- function(config = NULL,
     stop("sendToSlurm is TRUE, but SLURM is not available. Stopping.")
   }
 
-  # Generate SLURM configuration if sending to SLURM
-  if (sendToSlurm) {
-    slurmConfig <- setSlurmConfig(slurmQOS = slurmQOS, tasks32 = tasks32)
-  }
-
   # Check if an already existing path was given
   if (!is.null(path) && file.exists(path)) {
     message("Given path already exists. Restarting on this path.")
@@ -98,6 +93,12 @@ initModel <- function(config = NULL,
     }
 
     createRunFolder(path, cfg)
+  }
+
+  # Generate SLURM configuration if sending to SLURM
+  if (sendToSlurm) {
+    nmbrRegi <- length(cfg[["regions"]])
+    slurmConfig <- setSlurmConfig(slurmQOS = slurmQOS, tasks32 = tasks32, nmbrRegi = nmbrRegi)
   }
 
   # Copy gams files if this is not a restart run or if this is specified in restart parameters

--- a/R/initModel.R
+++ b/R/initModel.R
@@ -40,7 +40,7 @@ initModel <- function(config = NULL,
                       restart = NULL,
                       sendToSlurm = NULL,
                       slurmQOS = "default",
-                      tasksPerNode = 16,
+                      tasksPerNode = NULL,
                       tasks32 = FALSE) {
 
   if (!dir.exists(outputFolder)) {
@@ -99,6 +99,9 @@ initModel <- function(config = NULL,
 
   # Generate SLURM configuration if sending to SLURM
   if (sendToSlurm) {
+    if (slurmQOS == "default" && !is.null(cfg[["slurmQOS"]])) slurmQOS <- cfg[["slurmQOS"]]
+    if (is.null(tasksPerNode) && !is.null(cfg[["tasksPerNode"]])) tasksPerNode <- cfg[["tasksPerNode"]]
+    if (isFALSE(tasks32) && isTRUE(cfg[["tasks32"]])) tasks32 <- cfg[["tasks32"]]
     slurmConfig <- setSlurmConfig(slurmQOS = slurmQOS, tasksPerNode = tasksPerNode, tasks32 = tasks32)
   }
 

--- a/R/initModel.R
+++ b/R/initModel.R
@@ -25,6 +25,7 @@
 ##'  }
 #' @param sendToSlurm boolean whether or not the run should be started via SLURM
 #' @param slurmQOS character, slurm QOS to be used
+#' @param tasksPerNode numeric, number of tasks per node to be requested
 #' @param tasks32 boolean whether or not the SLURM run should be with 32 tasks
 #' @returns path (invisible)
 #'
@@ -39,6 +40,7 @@ initModel <- function(config = NULL,
                       restart = NULL,
                       sendToSlurm = NULL,
                       slurmQOS = "default",
+                      tasksPerNode = 16,
                       tasks32 = FALSE) {
 
   if (!dir.exists(outputFolder)) {
@@ -48,7 +50,7 @@ initModel <- function(config = NULL,
   # Check if SLURM is available. Start via SLURM if available, and directly otherwise.
   if (is.null(sendToSlurm)) {
     if (isSlurmAvailable()) {
-      message("SLURM is available. Run will be send to SLURM.")
+      message("SLURM is available. Run will be sent to SLURM.")
       sendToSlurm <- TRUE
     } else {
       message("SLURM is not available. Run will be executed directly.")
@@ -97,8 +99,7 @@ initModel <- function(config = NULL,
 
   # Generate SLURM configuration if sending to SLURM
   if (sendToSlurm) {
-    nmbrRegi <- length(cfg[["regions"]])
-    slurmConfig <- setSlurmConfig(slurmQOS = slurmQOS, tasks32 = tasks32, nmbrRegi = nmbrRegi)
+    slurmConfig <- setSlurmConfig(slurmQOS = slurmQOS, tasksPerNode = tasksPerNode, tasks32 = tasks32)
   }
 
   # Copy gams files if this is not a restart run or if this is specified in restart parameters

--- a/R/initModel.R
+++ b/R/initModel.R
@@ -39,7 +39,7 @@ initModel <- function(config = NULL,
                       references = NULL,
                       restart = NULL,
                       sendToSlurm = NULL,
-                      slurmQOS = "default",
+                      slurmQOS = NULL,
                       tasksPerNode = NULL,
                       tasks32 = FALSE) {
 
@@ -99,9 +99,12 @@ initModel <- function(config = NULL,
 
   # Generate SLURM configuration if sending to SLURM
   if (sendToSlurm) {
-    if (slurmQOS == "default" && !is.null(cfg[["slurmQOS"]])) slurmQOS <- cfg[["slurmQOS"]]
+    if (is.null(slurmQOS) && !is.null(cfg[["slurmQOS"]])) slurmQOS <- cfg[["slurmQOS"]]
     if (is.null(tasksPerNode) && !is.null(cfg[["tasksPerNode"]])) tasksPerNode <- cfg[["tasksPerNode"]]
-    if (isFALSE(tasks32) && isTRUE(cfg[["tasks32"]])) tasks32 <- cfg[["tasks32"]]
+    if (isFALSE(tasks32) && isTRUE(cfg[["tasks32"]])) {
+      tasks32 <- cfg[["tasks32"]]
+      warning("Using 32 tasks as defined in the config file.")
+    }
     slurmConfig <- setSlurmConfig(slurmQOS = slurmQOS, tasksPerNode = tasksPerNode, tasks32 = tasks32)
   }
 

--- a/R/setSlurmConfig.R
+++ b/R/setSlurmConfig.R
@@ -18,7 +18,7 @@ setSlurmConfig <- function(slurmQOS, tasksPerNode = 16, tasks32 = FALSE) {
   allowedQOS <- c("default", "priority", "standby", "short", "medium", "long")
 
   # Throw error if non-existing QOS is given
-  if (!slurmQOS %in% allowedQOS || length(slurmQOS) != 1) {
+  if (!is.null(slurmQOS) && (!slurmQOS %in% allowedQOS || length(slurmQOS) != 1)) {
     stop(paste0("Invalid or more than one QOS given. Available cluster QOS are:\t",
                 paste(allowedQOS, collapse = ", "), ".\n",
                 "The default QOS is priority for 16 tasks and short for 32 tasks.\n"))
@@ -26,7 +26,7 @@ setSlurmConfig <- function(slurmQOS, tasksPerNode = 16, tasks32 = FALSE) {
 
   # set default QOS
   if (isTRUE(tasks32)) {
-    if (slurmQOS == "default") {
+    if (is.null(slurmQOS) || slurmQOS == "default") {
       slurmQOS <- "short"
     } else if (slurmQOS %in% c("standby", "priority")) {
       # Throw an error if a job is started with 32 tasks on the priority partition
@@ -37,7 +37,7 @@ setSlurmConfig <- function(slurmQOS, tasksPerNode = 16, tasks32 = FALSE) {
                           " --constraint=broadwell --time=01:00:00")
     message("SLURM QOS is set to ", slurmQOS, ", using a Broadwell node with 32 CPUs.")
   } else {
-    if (slurmQOS == "default") slurmQOS <- "priority"
+    if (is.null(slurmQOS) || slurmQOS == "default") slurmQOS <- "priority"
     if (is.null(tasksPerNode)) tasksPerNode <- 16
     slurmConfig <- paste0("--qos=", slurmQOS, " --nodes=1 --tasks-per-node=", tasksPerNode)
     message("SLURM QOS is set to ", slurmQOS, " with ", tasksPerNode, " CPUs.")

--- a/R/setSlurmConfig.R
+++ b/R/setSlurmConfig.R
@@ -37,9 +37,8 @@ setSlurmConfig <- function(slurmQOS, tasksPerNode = 16, tasks32 = FALSE) {
                           " --constraint=broadwell --time=01:00:00")
     message("SLURM QOS is set to ", slurmQOS, ", using a Broadwell node with 32 CPUs.")
   } else {
-    if (slurmQOS == "default") {
-      slurmQOS <- "priority"
-    }
+    if (slurmQOS == "default") slurmQOS <- "priority"
+    if (is.null(tasksPerNode)) tasksPerNode <- 16
     slurmConfig <- paste0("--qos=", slurmQOS, " --nodes=1 --tasks-per-node=", tasksPerNode)
     message("SLURM QOS is set to ", slurmQOS, " with ", tasksPerNode, " CPUs.")
   }

--- a/R/setSlurmConfig.R
+++ b/R/setSlurmConfig.R
@@ -8,11 +8,12 @@
 #'
 #' @param slurmQOS string, name of the desired QOS (Quality of Service)
 #' @param tasks32 boolean, specify whether a node with 32 tasks should be requested
+#' @param numbrRegi numeric, number of regions
 #' @returns string with SLURM configuration
 #'
 #' @export
 
-setSlurmConfig <- function(slurmQOS, tasks32) {
+setSlurmConfig <- function(slurmQOS, tasks32, nmbrRegi) {
 
   allowedQOS <- c("default", "priority", "standby", "short", "medium", "long")
 
@@ -34,11 +35,14 @@ setSlurmConfig <- function(slurmQOS, tasks32) {
     }
     slurmConfig <- paste0("--qos=", slurmQOS, " --nodes=1 --tasks-per-node=32",
                           " --constraint=broadwell --time=01:00:00")
+    message("SLURM QOS is set to ", slurmQOS, ", using a Broadwell node with 32 CPUs.")
   } else {
     if (slurmQOS == "default") {
       slurmQOS <- "priority"
     }
-    slurmConfig <- paste0("--qos=", slurmQOS, " --nodes=1 --tasks-per-node=16")
+    tasksPerNode <- min(nmbrRegi * 4, 16) # Number of jobs that can be parallelized: Regions times types times locations
+    slurmConfig <- paste0("--qos=", slurmQOS, " --nodes=1 --tasks-per-node=", tasksPerNode)
+    message("SLURM QOS is set to ", slurmQOS, " with ", tasksPerNode, " CPUs.")
   }
 
   return(slurmConfig)

--- a/R/setSlurmConfig.R
+++ b/R/setSlurmConfig.R
@@ -7,13 +7,13 @@
 #' @author Ricarda Rosemann
 #'
 #' @param slurmQOS string, name of the desired QOS (Quality of Service)
+#' @param tasksPerNode numeric, number of tasks per node to be requested
 #' @param tasks32 boolean, specify whether a node with 32 tasks should be requested
-#' @param numbrRegi numeric, number of regions
 #' @returns string with SLURM configuration
 #'
 #' @export
 
-setSlurmConfig <- function(slurmQOS, tasks32, nmbrRegi) {
+setSlurmConfig <- function(slurmQOS, tasksPerNode = 16, tasks32 = FALSE) {
 
   allowedQOS <- c("default", "priority", "standby", "short", "medium", "long")
 
@@ -40,7 +40,6 @@ setSlurmConfig <- function(slurmQOS, tasks32, nmbrRegi) {
     if (slurmQOS == "default") {
       slurmQOS <- "priority"
     }
-    tasksPerNode <- min(nmbrRegi * 4, 16) # Number of jobs that can be parallelized: Regions times types times locations
     slurmConfig <- paste0("--qos=", slurmQOS, " --nodes=1 --tasks-per-node=", tasksPerNode)
     message("SLURM QOS is set to ", slurmQOS, " with ", tasksPerNode, " CPUs.")
   }

--- a/inst/config/default.yaml
+++ b/inst/config/default.yaml
@@ -59,6 +59,17 @@ reportingTemplate: onlyRes
 historic: NULL
 
 
+# slurm settings ---------------------------------------------------------------
+
+### slurm quality of service (= QOS)
+slurmQOS: NULL
+
+### tasks per node
+tasksPerNode: NULL
+
+### Whether to use a node with up to 32 tasks
+tasks32: FALSE
+
 # data -------------------------------------------------------------------------
 
 ### input data revision ###

--- a/man/initModel.Rd
+++ b/man/initModel.Rd
@@ -12,7 +12,7 @@ initModel(
   references = NULL,
   restart = NULL,
   sendToSlurm = NULL,
-  slurmQOS = "default",
+  slurmQOS = NULL,
   tasksPerNode = NULL,
   tasks32 = FALSE
 )

--- a/man/initModel.Rd
+++ b/man/initModel.Rd
@@ -13,7 +13,7 @@ initModel(
   restart = NULL,
   sendToSlurm = NULL,
   slurmQOS = "default",
-  tasksPerNode = 16,
+  tasksPerNode = NULL,
   tasks32 = FALSE
 )
 }

--- a/man/initModel.Rd
+++ b/man/initModel.Rd
@@ -13,6 +13,7 @@ initModel(
   restart = NULL,
   sendToSlurm = NULL,
   slurmQOS = "default",
+  tasksPerNode = 16,
   tasks32 = FALSE
 )
 }
@@ -42,6 +43,8 @@ BRICK-internal config folder is used.}
 \item{sendToSlurm}{boolean whether or not the run should be started via SLURM}
 
 \item{slurmQOS}{character, slurm QOS to be used}
+
+\item{tasksPerNode}{numeric, number of tasks per node to be requested}
 
 \item{tasks32}{boolean whether or not the SLURM run should be with 32 tasks}
 }

--- a/man/setSlurmConfig.Rd
+++ b/man/setSlurmConfig.Rd
@@ -4,12 +4,14 @@
 \alias{setSlurmConfig}
 \title{Set the SLURM configuration}
 \usage{
-setSlurmConfig(slurmQOS, tasks32)
+setSlurmConfig(slurmQOS, tasks32, nmbrRegi)
 }
 \arguments{
 \item{slurmQOS}{string, name of the desired QOS (Quality of Service)}
 
 \item{tasks32}{boolean, specify whether a node with 32 tasks should be requested}
+
+\item{numbrRegi}{numeric, number of regions}
 }
 \value{
 string with SLURM configuration

--- a/man/setSlurmConfig.Rd
+++ b/man/setSlurmConfig.Rd
@@ -4,14 +4,14 @@
 \alias{setSlurmConfig}
 \title{Set the SLURM configuration}
 \usage{
-setSlurmConfig(slurmQOS, tasks32, nmbrRegi)
+setSlurmConfig(slurmQOS, tasksPerNode = 16, tasks32 = FALSE)
 }
 \arguments{
 \item{slurmQOS}{string, name of the desired QOS (Quality of Service)}
 
-\item{tasks32}{boolean, specify whether a node with 32 tasks should be requested}
+\item{tasksPerNode}{numeric, number of tasks per node to be requested}
 
-\item{numbrRegi}{numeric, number of regions}
+\item{tasks32}{boolean, specify whether a node with 32 tasks should be requested}
 }
 \value{
 string with SLURM configuration


### PR DESCRIPTION
Enables to choose the number of CPUs to be requested manually; the default remains at 16.

This can be used to adapt CPUs to the number of parallel computations (e.g. with one region, two types and two locations this should be only 4) or to customize the distribution of user ressources.

Closes #38 .