### PR TITLE
Correct findLastRun

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1058145'
+ValidationKey: '1078488'
 AutocreateReadme: no
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ type: software
 title: |-
   brick: Building sector model with heterogeneous renovation and construction of
       the stock
-version: 0.5.3
-date-released: '2024-08-30'
+version: 0.5.4
+date-released: '2024-09-06'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of
     the stock
-Version: 0.5.3
-Date: 2024-08-30
+Version: 0.5.4
+Date: 2024-09-06
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/R/findLastRun.R
+++ b/R/findLastRun.R
@@ -11,17 +11,11 @@
 findLastRun <- function(outputFolder) {
 
   if (dir.exists(outputFolder)) {
-    paths <- list.dirs(outputFolder, recursive = FALSE)
     regexStamp <- "\\d{4}-\\d{2}-\\d{2}_\\d{2}\\.\\d{2}\\.\\d{2}"
-    stamp <- sub(
-      paste0("^.*_(", regexStamp, ")$"),
-      "\\1",
-      grep(regexStamp, paths, value = TRUE)
-    )
+    paths <- list.files(outputFolder, pattern = regexStamp, all.files = TRUE)
+    stamp <- sub(paste0("^.*_(", regexStamp, ")$"), "\\1", paths)
     if (length(stamp) > 0) {
       path <- paths[which(stamp == max(stamp))]
-    } else if (length(paths) == 1) {
-      path <- paths
     } else {
       stop("Cannot identify the most recent run. Please provide a path")
     }
@@ -31,5 +25,5 @@ findLastRun <- function(outputFolder) {
          outputFolder)
   }
 
-  return(path)
+  return(file.path(outputFolder, path))
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Building sector model with heterogeneous renovation and construction of the stock
 
-R package **brick**, version **0.5.3**
+R package **brick**, version **0.5.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/brick)](https://cran.r-project.org/package=brick)  [![R build status](https://github.com/pik-piam/brick/workflows/check/badge.svg)](https://github.com/pik-piam/brick/actions) [![codecov](https://codecov.io/gh/pik-piam/brick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/brick) 
 
@@ -50,7 +50,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **brick** in publications use:
 
-Hasse R, Rosemann R (2024). _brick: Building sector model with heterogeneous renovation and construction of the stock_. R package version 0.5.3, <https://github.com/pik-piam/brick>.
+Hasse R, Rosemann R (2024). _brick: Building sector model with heterogeneous renovation and construction of the stock_. R package version 0.5.4, <https://github.com/pik-piam/brick>.
 
 A BibTeX entry for LaTeX users is
 
@@ -60,7 +60,7 @@ A BibTeX entry for LaTeX users is
 the stock},
   author = {Robin Hasse and Ricarda Rosemann},
   year = {2024},
-  note = {R package version 0.5.3},
+  note = {R package version 0.5.4},
   url = {https://github.com/pik-piam/brick},
 }
 ```

--- a/inst/config/minimal.yaml
+++ b/inst/config/minimal.yaml
@@ -3,6 +3,6 @@ title: "fastTestRun"
 basedOn: "default.yaml"
 # scope and resolution
 periods: [2000, 2005, 2010, 2015, 2020, 2030, 2040]
-regionmapping: "input/regionmappingEUplus.csv"
-regions: DEU
+regionmapping: ["regionmappingEU27asOne.csv", "mredgebuildings"]
+regions: EUR
 ...


### PR DESCRIPTION
findLastRun now ignores folders with no time stamp; this fixes the error that findLastRun returned the wrong path if folders with no time stamp were present (see issue #61 ).

Even if only one folder is present, which does not have a time stamp, this folder is not found - this functionality existed before, but I would think this is a rare edge case.

In addition, I adapted the regionmapping specification in ```minimal.yaml```, making it runnable again in the current version.