### PR TITLE
Allow to pass time limit to SLURM, further minor adaptations

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1098790'
+ValidationKey: '1119048'
 AutocreateReadme: no
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1119048'
+ValidationKey: '1119832'
 AutocreateReadme: no
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ title: |-
   brick: Building sector model with heterogeneous renovation and construction of
       the stock
 version: 0.5.6
-date-released: '2024-09-17'
+date-released: '2024-10-01'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ type: software
 title: |-
   brick: Building sector model with heterogeneous renovation and construction of
       the stock
-version: 0.5.5
-date-released: '2024-09-12'
+version: 0.5.6
+date-released: '2024-09-17'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of
     the stock
-Version: 0.5.5
-Date: 2024-09-12
+Version: 0.5.6
+Date: 2024-09-17
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Package: brick
 Title: Building sector model with heterogeneous renovation and construction of
     the stock
 Version: 0.5.6
-Date: 2024-09-17
+Date: 2024-10-01
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/R/findLastRun.R
+++ b/R/findLastRun.R
@@ -12,7 +12,7 @@ findLastRun <- function(outputFolder) {
 
   if (dir.exists(outputFolder)) {
     regexStamp <- "\\d{4}-\\d{2}-\\d{2}_\\d{2}\\.\\d{2}\\.\\d{2}"
-    paths <- list.files(outputFolder, pattern = regexStamp, all.files = TRUE)
+    paths <- list.files(outputFolder, pattern = paste0(regexStamp, "$"), all.files = TRUE)
     stamp <- sub(paste0("^.*_(", regexStamp, ")$"), "\\1", paths)
     if (length(stamp) > 0) {
       path <- paths[which(stamp == max(stamp))]

--- a/R/findLastRun.R
+++ b/R/findLastRun.R
@@ -12,7 +12,8 @@ findLastRun <- function(outputFolder) {
 
   if (dir.exists(outputFolder)) {
     regexStamp <- "\\d{4}-\\d{2}-\\d{2}_\\d{2}\\.\\d{2}\\.\\d{2}"
-    paths <- list.files(outputFolder, pattern = paste0(regexStamp, "$"), all.files = TRUE)
+    paths <- list.dirs(outputFolder, recursive = FALSE)
+    paths <- grep(paste0(regexStamp, "$"), paths, value = TRUE)
     stamp <- sub(paste0("^.*_(", regexStamp, ")$"), "\\1", paths)
     if (length(stamp) > 0) {
       path <- paths[which(stamp == max(stamp))]
@@ -25,5 +26,5 @@ findLastRun <- function(outputFolder) {
          outputFolder)
   }
 
-  return(file.path(outputFolder, path))
+  return(path)
 }

--- a/R/initModel.R
+++ b/R/initModel.R
@@ -28,6 +28,7 @@
 #' @param sendToSlurm boolean whether or not the run should be started via SLURM
 #' @param slurmQOS character, slurm QOS to be used
 #' @param tasksPerNode numeric, number of tasks per node to be requested
+#' @param timeLimit character, time limit of the slurm job given in the format hh:mm:ss
 #' @param tasks32 boolean whether or not the SLURM run should be with 32 tasks
 #' @returns path (invisible)
 #'
@@ -43,14 +44,23 @@ initModel <- function(config = NULL,
                       sendToSlurm = NULL,
                       slurmQOS = NULL,
                       tasksPerNode = NULL,
+                      timeLimit = NULL,
                       tasks32 = FALSE) {
 
   if (!dir.exists(outputFolder)) {
     dir.create(outputFolder)
   }
 
-  # Check if SLURM is available. Start via SLURM if available, and directly otherwise.
-  if (is.null(sendToSlurm)) {
+  if (isTRUE(sendToSlurm)) {
+    if (isSlurmAvailable()) {
+      message("Run will be sent to SLURM")
+    } else {
+      stop("sendToSlurm is TRUE, but SLURM is not available. Stopping.")
+    }
+  } else if (isFALSE(sendToSlurm)) {
+    message("Run will be executed directly.")
+  } else {
+    # Check if SLURM is available. Start via SLURM if available, and directly otherwise.
     if (isSlurmAvailable()) {
       message("SLURM is available. Run will be sent to SLURM.")
       sendToSlurm <- TRUE
@@ -58,8 +68,6 @@ initModel <- function(config = NULL,
       message("SLURM is not available. Run will be executed directly.")
       sendToSlurm <- FALSE
     }
-  } else if (isTRUE(sendToSlurm) && !isSlurmAvailable()) {
-    stop("sendToSlurm is TRUE, but SLURM is not available. Stopping.")
   }
 
   # Check if this is a restart run and determine the path to be restarted
@@ -68,9 +76,9 @@ initModel <- function(config = NULL,
       message("Restarting on given path: ", path)
     } else if (is.null(path)) {
       path <- findLastRun(outputFolder)
-      message("No path given or given path does not exist. Restarting on the latest run: ", path)
+      message("Restart: No path given or given path does not exist. Restarting on the latest run: ", path)
     } else {
-      stop("You passed a non-existing path in a restart run. Stopping.")
+      stop("Restart: You passed a non-existing path in a restart run. Stopping.")
     }
     if (isTRUE(restart)) {
       message("No restart options were specified. ",
@@ -108,14 +116,15 @@ initModel <- function(config = NULL,
   }
 
   # Generate SLURM configuration if sending to SLURM
-  if (sendToSlurm) {
+  if (isTRUE(sendToSlurm)) {
     if (is.null(slurmQOS) && !is.null(cfg[["slurmQOS"]])) slurmQOS <- cfg[["slurmQOS"]]
     if (is.null(tasksPerNode) && !is.null(cfg[["tasksPerNode"]])) tasksPerNode <- cfg[["tasksPerNode"]]
     if (isFALSE(tasks32) && isTRUE(cfg[["tasks32"]])) {
       tasks32 <- cfg[["tasks32"]]
       warning("Using 32 tasks as defined in the config file.")
     }
-    slurmConfig <- setSlurmConfig(slurmQOS = slurmQOS, tasksPerNode = tasksPerNode, tasks32 = tasks32)
+    slurmConfig <- setSlurmConfig(slurmQOS = slurmQOS, tasksPerNode = tasksPerNode, tasks32 = tasks32,
+                                  timeLimit = timeLimit)
   }
 
   # Copy gams files if this is not a restart run or if this is specified in restart parameters
@@ -144,7 +153,7 @@ initModel <- function(config = NULL,
     exitCode <- system(paste0("sbatch --job-name=",
                               title,
                               " --output=", logFilePath,
-                              " --mail-type=END",
+                              " --mail-type=END,FAIL",
                               " --comment=BRICK",
                               " --wrap=\"",
                               paste("Rscript", slurmScriptPath, path, brickDir, isDev),

--- a/R/readConfig.R
+++ b/R/readConfig.R
@@ -26,7 +26,7 @@ readConfig <- function(config = NULL, configFolder = NULL, readDirect = FALSE) {
   # Directly read the file without considering basis configs
   if (readDirect) {
     if (!file.exists(config)) {
-      stop("The config", config, "that you want read directly does not exist. ",
+      stop("The config ", config, " that you want read directly does not exist. ",
            "If this is a restart run, your run folder likely misses the config file.")
     }
     if (!is.null(configFolder)) {

--- a/R/setSlurmConfig.R
+++ b/R/setSlurmConfig.R
@@ -9,11 +9,12 @@
 #' @param slurmQOS string, name of the desired QOS (Quality of Service)
 #' @param tasksPerNode numeric, number of tasks per node to be requested
 #' @param tasks32 boolean, specify whether a node with 32 tasks should be requested
+#' @param timeLimit character, time limit of the slurm job given in the format hh:mm:ss
 #' @returns string with SLURM configuration
 #'
 #' @export
 
-setSlurmConfig <- function(slurmQOS, tasksPerNode = 16, tasks32 = FALSE) {
+setSlurmConfig <- function(slurmQOS, tasksPerNode = 16, tasks32 = FALSE, timeLimit = NULL) {
 
   allowedQOS <- c("default", "priority", "standby", "short", "medium", "long")
 
@@ -41,6 +42,7 @@ setSlurmConfig <- function(slurmQOS, tasksPerNode = 16, tasks32 = FALSE) {
     if (is.null(tasksPerNode)) tasksPerNode <- 16
     slurmConfig <- paste0("--qos=", slurmQOS, " --nodes=1 --tasks-per-node=", tasksPerNode)
     message("SLURM QOS is set to ", slurmQOS, " with ", tasksPerNode, " CPUs.")
+    if (!is.null(timeLimit)) slurmConfig <- paste0(slurmConfig, " --time=", timeLimit)
   }
 
   return(slurmConfig)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Building sector model with heterogeneous renovation and construction of the stock
 
-R package **brick**, version **0.5.5**
+R package **brick**, version **0.5.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/brick)](https://cran.r-project.org/package=brick)  [![R build status](https://github.com/pik-piam/brick/workflows/check/badge.svg)](https://github.com/pik-piam/brick/actions) [![codecov](https://codecov.io/gh/pik-piam/brick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/brick) 
 
@@ -50,7 +50,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **brick** in publications use:
 
-Hasse R, Rosemann R (2024). _brick: Building sector model with heterogeneous renovation and construction of the stock_. R package version 0.5.5, <https://github.com/pik-piam/brick>.
+Hasse R, Rosemann R (2024). _brick: Building sector model with heterogeneous renovation and construction of the stock_. R package version 0.5.6, <https://github.com/pik-piam/brick>.
 
 A BibTeX entry for LaTeX users is
 
@@ -60,7 +60,7 @@ A BibTeX entry for LaTeX users is
 the stock},
   author = {Robin Hasse and Ricarda Rosemann},
   year = {2024},
-  note = {R package version 0.5.5},
+  note = {R package version 0.5.6},
   url = {https://github.com/pik-piam/brick},
 }
 ```

--- a/man/initModel.Rd
+++ b/man/initModel.Rd
@@ -14,6 +14,7 @@ initModel(
   sendToSlurm = NULL,
   slurmQOS = NULL,
   tasksPerNode = NULL,
+  timeLimit = NULL,
   tasks32 = FALSE
 )
 }
@@ -47,6 +48,8 @@ BRICK-internal config folder is used.}
 \item{slurmQOS}{character, slurm QOS to be used}
 
 \item{tasksPerNode}{numeric, number of tasks per node to be requested}
+
+\item{timeLimit}{character, time limit of the slurm job given in the format hh:mm:ss}
 
 \item{tasks32}{boolean whether or not the SLURM run should be with 32 tasks}
 }

--- a/man/setSlurmConfig.Rd
+++ b/man/setSlurmConfig.Rd
@@ -4,7 +4,7 @@
 \alias{setSlurmConfig}
 \title{Set the SLURM configuration}
 \usage{
-setSlurmConfig(slurmQOS, tasksPerNode = 16, tasks32 = FALSE)
+setSlurmConfig(slurmQOS, tasksPerNode = 16, tasks32 = FALSE, timeLimit = NULL)
 }
 \arguments{
 \item{slurmQOS}{string, name of the desired QOS (Quality of Service)}
@@ -12,6 +12,8 @@ setSlurmConfig(slurmQOS, tasksPerNode = 16, tasks32 = FALSE)
 \item{tasksPerNode}{numeric, number of tasks per node to be requested}
 
 \item{tasks32}{boolean, specify whether a node with 32 tasks should be requested}
+
+\item{timeLimit}{character, time limit of the slurm job given in the format hh:mm:ss}
 }
 \value{
 string with SLURM configuration


### PR DESCRIPTION
This PR collects some very minor changes:
- allow to pass a time limit to SLURM. This allows to run BRICK easily when maintenance is scheduled and maybe runs start earlier on non-priority QOS
- correct yet another error in ```findLastRun```: The function now ignores files when searching for the latest run folder (as long as the file has some sort of file name ending - the criterion is that the time stamp is at the very end of the file/directory name)
- also receive an email notification from SLURM if a run fails
- slightly more extensive messaging when restarting and on whether SLURM is used or not.

Closes #54 .