### PR TITLE
Assume initial mix of building shell efficiencies

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1180295'
+ValidationKey: '10231110'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
@@ -7,3 +7,4 @@ allowLinterWarnings: no
 AddLogoReadme: man/figures/logo_text_wide.svg
 LogoHeightReadme: 70
 enforceVersionUpdate: no
+skipCoverage: no

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,14 +23,14 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
-            any::lucode2
-            any::covr
-            any::madrat
-            any::magclass
-            any::citation
-            any::gms
-            any::goxygen
-            any::GDPuc
+            lucode2
+            covr
+            madrat
+            magclass
+            citation
+            gms
+            goxygen
+            GDPuc
           # piam packages also available on CRAN (madrat, magclass, citation,
           # gms, goxygen, GDPuc) will usually have an outdated binary version
           # available; by using extra-packages we get the newest version
@@ -63,6 +63,6 @@ jobs:
         shell: Rscript {0}
         run: |
           nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
-          if(length(nonDummyTests) > 0) covr::codecov(quiet = FALSE)
+          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: '^tests/testthat/_snaps/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c  # frozen: v4.6.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
     hooks:
     -   id: check-case-conflict
     -   id: check-json
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: bae853d82da476eee0e0a57960ee6b741a3b3fb7  # frozen: v0.4.3
+    rev: 3b70240796cdccbe1474b0176560281aaded97e6  # frozen: v0.4.3.9003
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'brick: Building sector model with heterogeneous renovation and construction
   of the stock'
-version: 0.5.9
-date-released: '2024-10-09'
+version: 0.5.10
+date-released: '2024-12-04'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of the stock
-Version: 0.5.9
-Date: 2024-10-09
+Version: 0.5.10
+Date: 2024-12-04
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <a href=''><img src='man/figures/logo_text_wide.svg' align='right' alt='logo' height=70 /></a> Building sector model with heterogeneous renovation and construction of the stock
 
-R package **brick**, version **0.5.9**
+R package **brick**, version **0.5.10**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/brick)](https://cran.r-project.org/package=brick)  [![R build status](https://github.com/pik-piam/brick/workflows/check/badge.svg)](https://github.com/pik-piam/brick/actions) [![codecov](https://codecov.io/gh/pik-piam/brick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/brick) [![r-universe](https://pik-piam.r-universe.dev/badges/brick)](https://pik-piam.r-universe.dev/builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **brick** in publications use:
 
-Hasse R, Rosemann R (2024). _brick: Building sector model with heterogeneous renovation and construction of the stock_. R package version 0.5.9, <https://github.com/pik-piam/brick>.
+Hasse R, Rosemann R (2024). _brick: Building sector model with heterogeneous renovation and construction of the stock_. R package version 0.5.10, <https://github.com/pik-piam/brick>.
 
 A BibTeX entry for LaTeX users is
 
@@ -57,7 +57,7 @@ A BibTeX entry for LaTeX users is
   title = {brick: Building sector model with heterogeneous renovation and construction of the stock},
   author = {Robin Hasse and Ricarda Rosemann},
   year = {2024},
-  note = {R package version 0.5.9},
+  note = {R package version 0.5.10},
   url = {https://github.com/pik-piam/brick},
 }
 ```

--- a/inst/config/default.yaml
+++ b/inst/config/default.yaml
@@ -78,10 +78,11 @@ tasksPerNode: NULL
 ### Whether to use a node with up to 32 tasks
 tasks32: FALSE
 
+
 # data -------------------------------------------------------------------------
 
 ### input data revision ###
-inputRevision: "0.7"
+inputRevision: "0.8.3"
 
 ### force download ###
 # force the model to download new input data even though it seems unchanged

--- a/inst/extdata/sectoral/buildingShell.csv
+++ b/inst/extdata/sectoral/buildingShell.csv
@@ -1,4 +1,4 @@
-bs,relDem,energyLadder
-low,1.0,3
-med,0.7,2
-high,0.4,1
+bs,relDem,initShare,energyLadder
+low,1.0,0.80,3
+med,0.7,0.15,2
+high,0.4,0.05,1


### PR DESCRIPTION
- add assumption on initial mix of building shell classes to mapping
- increase input data revision to a version that assumes an initial mix
- reallocate everything to `"low"` efficiency for `ignoreShell = TRUE`
  - We should consider recalculating the UE demand in that case to maintain the average demand