### PR TITLE
Bugfix: aggregation of matching renovation for calibration

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1679754'
+ValidationKey: '1700496'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'brick: Building sector model with heterogeneous renovation and construction
   of the stock'
-version: 0.8.3
-date-released: '2025-05-30'
+version: 0.8.4
+date-released: '2025-06-05'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of the stock
-Version: 0.8.3
-Date: 2025-05-30
+Version: 0.8.4
+Date: 2025-06-05
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <a href=''><img src='man/figures/logo_text_wide.svg' align='right' alt='logo' height=70 /></a> Building sector model with heterogeneous renovation and construction of the stock
 
-R package **brick**, version **0.8.3**
+R package **brick**, version **0.8.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/brick)](https://cran.r-project.org/package=brick) [![R build status](https://github.com/pik-piam/brick/workflows/check/badge.svg)](https://github.com/pik-piam/brick/actions) [![codecov](https://codecov.io/gh/pik-piam/brick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/brick) [![r-universe](https://pik-piam.r-universe.dev/badges/brick)](https://pik-piam.r-universe.dev/builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **brick** in publications use:
 
-Hasse R, Rosemann R (2025). "brick: Building sector model with heterogeneous renovation and construction of the stock." Version: 0.8.3, <https://github.com/pik-piam/brick>.
+Hasse R, Rosemann R (2025). "brick: Building sector model with heterogeneous renovation and construction of the stock." Version: 0.8.4, <https://github.com/pik-piam/brick>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,9 +56,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {brick: Building sector model with heterogeneous renovation and construction of the stock},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2025-05-30},
+  date = {2025-06-05},
   year = {2025},
   url = {https://github.com/pik-piam/brick},
-  note = {Version: 0.8.3},
+  note = {Version: 0.8.4},
 }
 ```

--- a/man/createCalibrationTarget.Rd
+++ b/man/createCalibrationTarget.Rd
@@ -4,12 +4,14 @@
 \alias{createCalibrationTarget}
 \title{Create calibration targets}
 \usage{
-createCalibrationTarget(path, outDir)
+createCalibrationTarget(path, outDir, digits = 4)
 }
 \arguments{
 \item{path}{character, directory of matching folder}
 
 \item{outDir}{character, directory to save files in}
+
+\item{digits}{integer indicating the number of decimal places}
 }
 \description{
 read results from matching run and aggregate them spatially and temporally

--- a/man/dot-makeIdentVin.Rd
+++ b/man/dot-makeIdentVin.Rd
@@ -7,7 +7,7 @@
 .makeIdentVin(x)
 }
 \arguments{
-\item{x}{data.frame with brick parameter, requires vin and value column}
+\item{x}{data.frame with brick parameter, requires vin and value columns}
 }
 \value{
 data.frame with identical structure but averaged values


### PR DESCRIPTION
This PR fixes a bug in the temporal aggregation of the renovation from a matching run for the calibration target.

## bug fix

### intended behaviour
In a first step, we calculate a naive estimate assuming that across the 5yr time step, the average across the five individual years in renovated. The zero flows are corrected to match the total. In a second step, we find the final values by minimising their deviation from this estimate while respecting the stock balances.

### bug
Due to the bug, the zero flows of the naive estimate could get too big such that the totals were not matched. The optimisation still produced compatible values but they were distorted by the zero flows. As they are dominant and the optimisation minimises squared errors, the impact was potentially big and could have easily led to renovation activity that was too low to comply with life time assumptions.

### fix
With the fix, the estimate becomes basically feasible making the correction by the optimisation practically irrelevant - at least for the run that I looked at. However, you can still think of renovation time series with estimates that cannot fulfil the balances where the correction by the optimisation becomes relevant.

## further changes

### multiple solving attempts
In rare cases, the optimisation fails due to infeasible constraints. This seems to be a purely numerical issue. I could solve this by further solving attempts, where I picked another of the initial constraints to be removed to make the set of constraints independent. I set a maximum of 5 attempts, though it has never taken more than one additional attempt so far. While writing this I'm wondering, if the constraints are still dependent and we could remove 2 constraints (1 per equation) which would make the iterative approach obsolete. Haven't checked this yet.

### check deviation
I implemented a check that throws a warning if the optimisation result $y$ deviates too much from the estimate $x$. As an deviation indicator $\delta$, I used SSE divided by the L2 norm of te estimate.
$\delta = \dfrac{\sum_i(y_i - x_i)^2}{\sum_j x_j^2}$
The default accepted value is $\delta_\text{max} = 10^{-4}$, but the actual values in my run are below $10^{-7}$ which looks to me as if the optimisation only corrects within numerical tolerances - which is a good sign of course.