### PR TITLE
Bugfix: remove consideration of dt for standing life time

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1700496'
+ValidationKey: '1721335'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'brick: Building sector model with heterogeneous renovation and construction
   of the stock'
-version: 0.8.4
-date-released: '2025-06-05'
+version: 0.8.5
+date-released: '2025-06-12'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of the stock
-Version: 0.8.4
-Date: 2025-06-05
+Version: 0.8.5
+Date: 2025-06-12
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/R/createCalibrationTarget.R
+++ b/R/createCalibrationTarget.R
@@ -65,7 +65,7 @@ createCalibrationTarget <- function(path, outDir, digits = 4) {
 
   # find renovation transition closest to average renovation while satisfying
   # stock balances
-  correctRenovation <- function(x, key, maxAttempts = 5, maxDeviation = 1E-4) {
+  correctRenovation <- function(x, key, maxAttempts = 5, maxDeviation = 1E-4, tol = 1E-8) {
 
     keyMsg <- paste(names(key), lapply(key[1, ], as.character),
                     sep = " = ", collapse = ", ")
@@ -99,11 +99,12 @@ createCalibrationTarget <- function(path, outDir, digits = 4) {
       constraintMatrixIndep <- constraintMatrix[, constraintsIndep]
 
       # solve
+      lb <- if (attempt < maxAttempts / 2) 0 else -tol
       r <- tryCatch(
         quadprog::solve.QP(Dmat = identityMatrix,
                            dvec = x$estimate,
                            Amat = cbind(constraintMatrixIndep, identityMatrix),
-                           bvec = c(constraintRhsIndep, rep(0, nrow(x))),
+                           bvec = c(constraintRhsIndep, rep(lb, nrow(x))),
                            meq = length(constraintRhsIndep)),
         error = conditionMessage
       )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <a href=''><img src='man/figures/logo_text_wide.svg' align='right' alt='logo' height=70 /></a> Building sector model with heterogeneous renovation and construction of the stock
 
-R package **brick**, version **0.8.4**
+R package **brick**, version **0.8.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/brick)](https://cran.r-project.org/package=brick) [![R build status](https://github.com/pik-piam/brick/workflows/check/badge.svg)](https://github.com/pik-piam/brick/actions) [![codecov](https://codecov.io/gh/pik-piam/brick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/brick) [![r-universe](https://pik-piam.r-universe.dev/badges/brick)](https://pik-piam.r-universe.dev/builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **brick** in publications use:
 
-Hasse R, Rosemann R (2025). "brick: Building sector model with heterogeneous renovation and construction of the stock." Version: 0.8.4, <https://github.com/pik-piam/brick>.
+Hasse R, Rosemann R (2025). "brick: Building sector model with heterogeneous renovation and construction of the stock." Version: 0.8.5, <https://github.com/pik-piam/brick>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,9 +56,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {brick: Building sector model with heterogeneous renovation and construction of the stock},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2025-06-05},
+  date = {2025-06-12},
   year = {2025},
   url = {https://github.com/pik-piam/brick},
-  note = {Version: 0.8.4},
+  note = {Version: 0.8.5},
 }
 ```


### PR DESCRIPTION
In the life time constraints of heating systems and building shells, we also consider the standing life time of the initial stock. In the calculation of the shares `p_shareRenBS` `p_shareRenHS` of buildings that have to be renovated or demolished due to life time consideration of these assets, we consider the length of the past time step in the life time calculation. This is correct for flows (i.e. past construction and renovation), as the average activity happens $\Delta t / 2$ before the nominal time step. But for standing life times, we consider the initial stock and not a flow. The stock is always referenced at the actual point in time. So the time step length should not be considered.

This PR fixes this but. This hopefully resolves inconsistencies between model versions with different temporal resolution.

Additionally, I added a tiny relaxation of inequality constraints in the aggregation of matching renovation flows to a lower temporal resolution. I observed edge cases where the optimisation remained infeasible even after multiple attempts. The constraints that assure positive values allow slightly negative values at later attempts now that should help solving. All values are later clipped to avoid negative values. There should be no relevant deviation as the relaxation in within numeric tolerances which likely caused the infeasibility.