### PR TITLE
Shift intangible costs to positive range

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1742102'
+ValidationKey: '1763751'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'brick: Building sector model with heterogeneous renovation and construction
   of the stock'
-version: 0.8.6
-date-released: '2025-06-18'
+version: 0.8.7
+date-released: '2025-07-04'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of the stock
-Version: 0.8.6
-Date: 2025-06-18
+Version: 0.8.7
+Date: 2025-07-04
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <a href=''><img src='man/figures/logo_text_wide.svg' align='right' alt='logo' height=70 /></a> Building sector model with heterogeneous renovation and construction of the stock
 
-R package **brick**, version **0.8.6**
+R package **brick**, version **0.8.7**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/brick)](https://cran.r-project.org/package=brick) [![R build status](https://github.com/pik-piam/brick/workflows/check/badge.svg)](https://github.com/pik-piam/brick/actions) [![codecov](https://codecov.io/gh/pik-piam/brick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/brick) [![r-universe](https://pik-piam.r-universe.dev/badges/brick)](https://pik-piam.r-universe.dev/builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **brick** in publications use:
 
-Hasse R, Rosemann R (2025). "brick: Building sector model with heterogeneous renovation and construction of the stock." Version: 0.8.6, <https://github.com/pik-piam/brick>.
+Hasse R, Rosemann R (2025). "brick: Building sector model with heterogeneous renovation and construction of the stock." Version: 0.8.7, <https://github.com/pik-piam/brick>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,9 +56,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {brick: Building sector model with heterogeneous renovation and construction of the stock},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2025-06-18},
+  date = {2025-07-04},
   year = {2025},
   url = {https://github.com/pik-piam/brick},
-  note = {Version: 0.8.6},
+  note = {Version: 0.8.7},
 }
 ```

--- a/inst/config/calibration.yaml
+++ b/inst/config/calibration.yaml
@@ -1,9 +1,9 @@
 ---
-title: "calibration"
+title: "calibration-mtch-12-06-shift"
 basedOn: "default.yaml"
 # scope and resolution
 granularity: lowGran
-periods: [2000, 2005, 2010, 2015, 2020, 2025, 2030, 2035, 2040, 2045, 2050]
+periods: [2000, 2005, 2010]
 startyear: 2005
 calibperiods: 2005
 regionmapping: ["regionmappingEU27asOne.csv", "mredgebuildings"]
@@ -20,7 +20,7 @@ switches:
 # parameters for calibration
 calibrationParameters:
   stepSizeInit: 80
-  iterations: 10
+  iterations: 15
   iterationsArmijo: 20
   sensitivityArmijo: 0.04
   modifyData: FALSE

--- a/inst/config/calibration.yaml
+++ b/inst/config/calibration.yaml
@@ -1,5 +1,5 @@
 ---
-title: "calibration-mtch-12-06-shift"
+title: "calibration"
 basedOn: "default.yaml"
 # scope and resolution
 granularity: lowGran
@@ -9,6 +9,7 @@ calibperiods: 2005
 regionmapping: ["regionmappingEU27asOne.csv", "mredgebuildings"]
 regions: EUR
 ignoreShell: TRUE
+statusQuoPreference: 0
 reportingTemplate: ignoreShell_onlyRes
 ltEternalShare: 0.05
 # switches
@@ -20,8 +21,7 @@ switches:
 # parameters for calibration
 calibrationParameters:
   stepSizeInit: 80
-  iterations: 15
+  iterations: 5
   iterationsArmijo: 20
   sensitivityArmijo: 0.04
-  modifyData: FALSE
 ...

--- a/inst/config/calibrationOptimFlows.yaml
+++ b/inst/config/calibrationOptimFlows.yaml
@@ -2,12 +2,14 @@
 title: "calibration-flows"
 basedOn: "default.yaml"
 # scope and resolution
-periods: [2005, 2010, 2015]
-startyear: 2010
-calibperiods: 2010
+granularity: lowGran
+periods: [2000, 2005, 2010]
+startyear: 2005
+calibperiods: 2005
 regionmapping: ["regionmappingEU27asOne.csv", "mredgebuildings"]
 regions: EUR
 ignoreShell: TRUE
+statusQuoPreference: 0
 reportingTemplate: ignoreShell_onlyRes
 ltEternalShare: 0.05
 # switches
@@ -16,12 +18,12 @@ switches:
   CALIBRATIONMETHOD: optimization
   TARGETFUNCTION: minsquare
   CALIBRATIONTYPE: flows
-  AGGREGATEDIM: vin
+  # AGGREGATEDIM: vin
+  FIXEDBUILDINGS: TRUE
 # parameters for calibration
 calibrationParameters:
   stepSizeInit: 10
-  iterations: 2
+  iterations: 5
   iterationsArmijo: 20
   sensitivityArmijo: 0.04
-  modifyData: FALSE
 ...

--- a/inst/config/calibrationOptimStocks.yaml
+++ b/inst/config/calibrationOptimStocks.yaml
@@ -23,5 +23,4 @@ calibrationParameters:
   iterations: 5
   iterationsArmijo: 20
   sensitivityArmijo: 0.04
-  modifyData: FALSE
 ...

--- a/inst/config/calibrationOptimStocksZero.yaml
+++ b/inst/config/calibrationOptimStocksZero.yaml
@@ -2,29 +2,28 @@
 title: "calibration-stocks-zeroF"
 basedOn: "default.yaml"
 # scope and resolution
-periods: [2000, 2010, 2020]
-startyear: 2010
-calibperiods: 2010
+granularity: lowGran
+periods: [2000, 2005, 2010]
+startyear: 2005
+calibperiods: 2005
 regionmapping: ["regionmappingEU27asOne.csv", "mredgebuildings"]
 regions: EUR
 ignoreShell: TRUE
 statusQuoPreference: 0
 reportingTemplate: ignoreShell_onlyRes
-ltFactor: 1.5
-ltEternalShare: 0.15
+ltEternalShare: 0.05
 # switches
 switches:
   RUNTYPE: calibration
   CALIBRATIONMETHOD: optimization
   TARGETFUNCTION: minsquare
   CALIBRATIONTYPE: stockszero
+  FIXEDBUILDINGS: TRUE
   # AGGREGATEDIM: vin
 # parameters for calibration
 calibrationParameters:
-  stepSizeInit: 1
-  iterations: 3
+  stepSizeInit: 10
+  iterations: 5
   iterationsArmijo: 20
   sensitivityArmijo: 0.04
-  deltaDiffQuotient: 0.1
-  modifyData: TRUE
 ...

--- a/inst/config/default.yaml
+++ b/inst/config/default.yaml
@@ -275,6 +275,12 @@ switches:
     # vin
   AGGREGATEDIM: FALSE
 
+  ### Shift intangible costs ###
+  # Should intangible costs be shifted to the positive range?
+    # TRUE
+    # FALSE
+  SHIFTINTANG: TRUE
+
 
 # gams parameters --------------------------------------------------------------
 # passed to gams
@@ -306,5 +312,4 @@ calibrationParameters:
   sensitivityArmijo: 0.01
   stepReduction: 0.5
   deltaDiffQuotient: 0.1
-  modifyData: FALSE
 ...

--- a/man/dot-addSpecCostToInput.Rd
+++ b/man/dot-addSpecCostToInput.Rd
@@ -14,7 +14,8 @@
   tcalib,
   vinExists,
   vinCalib,
-  varName = "x"
+  varName = "x",
+  shiftIntang = TRUE
 )
 }
 \arguments{
@@ -38,6 +39,8 @@
 
 \item{varName}{character, optimization variable to calculate specific costs from.
 Needs to be a column of optimVarCon and optimVarRen, should be one of 'x', 'xA' or 'xMin'.}
+
+\item{shiftIntang}{logical indicating whether intangible costs should be shifted to positive range}
 }
 \description{
 Write the specific costs to the input.gdx

--- a/man/dot-determineSpecCost.Rd
+++ b/man/dot-determineSpecCost.Rd
@@ -12,7 +12,8 @@
   flow = c("construction", "renovation"),
   varName = "x",
   vinExists = NULL,
-  vinCalib = NULL
+  vinCalib = NULL,
+  shiftIntang = TRUE
 )
 }
 \arguments{
@@ -32,6 +33,8 @@ Should be one of 'x', 'xA' or 'xMin'.}
 \item{vinExists}{data frame of vintages that exist for each time period}
 
 \item{vinCalib}{data frame with vintages that exist in calibration periods}
+
+\item{shiftIntang}{logical indicating whether intangible costs should be shifted to positive range}
 }
 \description{
 Assemble specific costs from initial specific costs and the optimization variable

--- a/man/dot-readCalibTarget.Rd
+++ b/man/dot-readCalibTarget.Rd
@@ -4,12 +4,10 @@
 \alias{.readCalibTarget}
 \title{Read calibration targets from input folder}
 \usage{
-.readCalibTarget(tcalib, modifyData = FALSE)
+.readCalibTarget(tcalib)
 }
 \arguments{
 \item{tcalib}{numeric, calibration time periods}
-
-\item{modifyData}{logical, switch to control whether to alter data read from matching}
 }
 \description{
 Read calibration targets from input folder


### PR DESCRIPTION
The intangible costs are shifted to the positige range in the following way:
Across the target heating system, determine the minimum intangible costs and shift all intangible costs by the absolute value of the minimum if it is negative. Thus all intangible costs should be non-negative.

### Additional changes
- I removed the option to modify matching data during the calibration; we don't need this anymore, because the matching and the calibration are now nicely harmonized.
- At one point during the calibration I remove the ```qty``` column. I now also filter for ```qty == "area"```. This should not be necessary anymore, as the filtering should already happen in the matching and this code bit actually  was kept by accident. But I would still suggest to keep it, because I find it more stable to filter for the expected entries before I remove a column.
- The calibration configs are a bit harmonized, but this is still subject to change, in particular as I have a setup based on a common calibration config file on another branch, which will be merged at some point.