### PR TITLE
Save renovation distribution

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,6 +3,7 @@
 ^\.buildlibrary$
 ^\.pre-commit-config\.yaml$
 ^\.github$
+^\.vscode$
 ^Makefile$
 ^workflow$
 ^output$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1805899'
+ValidationKey: '1805988'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1805187'
+ValidationKey: '1805899'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1784288'
+ValidationKey: '1805187'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .Rhistory
 .RData
 .Ruserdata
+.vscode/*
 output/*
 brick.Rproj

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'brick: Building sector model with heterogeneous renovation and construction
   of the stock'
-version: 0.8.8
-date-released: '2025-07-07'
+version: 0.8.9
+date-released: '2025-07-14'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ type: software
 title: 'brick: Building sector model with heterogeneous renovation and construction
   of the stock'
 version: 0.8.9
-date-released: '2025-07-14'
+date-released: '2025-07-22'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ type: software
 title: 'brick: Building sector model with heterogeneous renovation and construction
   of the stock'
 version: 0.8.9
-date-released: '2025-07-22'
+date-released: '2025-07-23'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of the stock
-Version: 0.8.8
-Date: 2025-07-07
+Version: 0.8.9
+Date: 2025-07-14
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of the stock
 Version: 0.8.9
-Date: 2025-07-14
+Date: 2025-07-22
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of the stock
 Version: 0.8.9
-Date: 2025-07-22
+Date: 2025-07-23
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/R/createParameters.R
+++ b/R/createParameters.R
@@ -243,13 +243,13 @@ createParameters <- function(m, config, inputDir) {
   # Calculate share of buildings that need to be renovated or demolished between
   # given time steps assuming a Weibull distribution of the technology life time.
   # When passing the standing life time, the share of the initial stock standing
-  # in ttot2 that has to be demolished or renovated until given time step is
+  # in ttotIn that has to be demolished or renovated until given time step is
   # calculated
-  shareRen <- function(params, standingLifeTime = NULL, timePeriods = NULL, returnDistr = FALSE) {
+  shareRen <- function(params, standingLifeTime = NULL, timePeriods = NULL) {
 
     if (is.null(timePeriods)) {
-      timePeriods <- expandSets(ttot2 = "ttot", "ttot", .m = m) %>%
-        filter(.data$ttot2 <= .data$ttot)
+      timePeriods <- expandSets(ttotIn = "ttot", ttotOut = "ttot", .m = m) %>%
+        filter(.data$ttotIn <= .data$ttotOut)
     }
 
     share <- timePeriods %>%
@@ -257,50 +257,43 @@ createParameters <- function(m, config, inputDir) {
       pivot_wider(names_from = "variable")
 
     share <- if (is.null(standingLifeTime)) {
-      # average past flow activity happened dt/2 before nominal time step ttot2
+      # average past flow activity happened dt/2 before nominal time step ttotIn
       share %>%
         left_join(readSymbol(p_dt) %>%
                     rename(dt = "value"),
-                  by = c(ttot2 = "ttot")) %>%
+                  by = c(ttotIn = "ttot")) %>%
         filter(!is.na(.data$dt)) %>%
-        mutate(lt = .data$ttot - (.data$ttot2 - .data$dt / 2),
+        mutate(lt = .data$ttotOut - (.data$ttotIn - .data$dt / 2),
                p0 = 0)
     } else {
       # standing life time considers stock not flows -> no consideration of dt
       share %>%
-        mutate(lt = .data$ttot - .data$ttot2 + standingLifeTime,
+        mutate(lt = .data$ttotOut - .data$ttotIn + standingLifeTime,
                p0 = pweibull(standingLifeTime, .data$shape, .data$scale))
     }
 
-    share <- share %>%
-      mutate(p  = pweibull(.data$lt, .data$shape, .data$scale))
-    share <- if (isFALSE(returnDistr)) {
-      share %>%
-        mutate(value = (.data$p - .data$p0) / (1 - .data$p0),
-               value = ifelse(.data$value > cutOffShare, 1, .data$value))
-    } else {
-      share %>%
-        rename(value = "p")
-    }
     share %>%
+      mutate(p  = pweibull(.data$lt, .data$shape, .data$scale)) %>%
+      mutate(value = (.data$p - .data$p0) / (1 - .data$p0),
+             value = ifelse(.data$value > cutOffShare, 1, .data$value)) %>%
       select(-any_of(c("shape", "scale", "dt", "lt", "p", "p0")))
   }
 
   ## building ====
 
   # parameter for monitoring purposes
-  p_probDem <- expandSets("region", "typ", ttot2 = "ttot", "ttot", .m = m) %>%
-    filter(.data[["ttot2"]] >= .data[["ttot"]]) %>%
+  p_probDem <- expandSets("region", "typ", ttotIn = "ttot", ttotOut = "ttot", .m = m) %>%
+    filter(.data[["ttotOut"]] >= .data[["ttotIn"]]) %>%
     left_join(lt, by = c("region", "typ"), relationship = "many-to-many") %>%
     pivot_wider(names_from = "variable") %>%
     mutate(value = (1 - config[["ltEternalShare"]]) *
-             pweibull(.data$ttot2 - .data$ttot,
+             pweibull(.data$ttotOut - .data$ttotIn,
                       .data$shape,
                       .data$scale * config[["ltFactor"]])) %>%
     select(-"shape", -"scale")
   p_probDem <- m$addParameter(
     name = "p_probDem",
-    domain = c("region", "typ", "ttot2", "ttot"),
+    domain = c("region", "typ", "ttotIn", "ttotOut"),
     records = p_probDem,
     description = "probability of a building having reached its end of life"
   )
@@ -341,26 +334,26 @@ createParameters <- function(m, config, inputDir) {
     name = "p_lifeTimeBS",
     domain = "region",
     records = p_lifeTimeBS,
-    description = "life time of heating system in yr"
+    description = "life time of building shell in yr"
   )
 
   p_shareRenBS <- shareRen(ltBs) %>%
-    select("region", "ttot2", "ttot", "value") %>%
-    toModelResolution(m)
+    select("region", "ttotIn", "ttotOut", "value") %>%
+    toModelResolution(m, ignoreDims = c("ttotIn", "ttotOut"))
   p_shareRenBS <- m$addParameter(
     name = "p_shareRenBS",
-    domain = c("region", "ttot2", "ttot"),
+    domain = c("region", "ttotIn", "ttotOut"),
     records = p_shareRenBS,
     description = "minimum share of renovation from the building shell reaching end of life"
   )
 
   # assumption: average life time of initial stock of building shells: 12 years
   p_shareRenBSinit <- shareRen(ltBs, standingLifeTime = 12) %>%
-    select("region", "ttot2", "ttot", "value") %>%
-    toModelResolution(m)
+    select("region", "ttotIn", "ttotOut", "value") %>%
+    toModelResolution(m, ignoreDims = c("ttotIn", "ttotOut"))
   p_shareRenBSinit <- m$addParameter(
     name = "p_shareRenBSinit",
-    domain = c("region", "ttot2", "ttot"),
+    domain = c("region", "ttotIn", "ttotOut"),
     records = p_shareRenBSinit,
     description = "minimum share of renovation from the building shell of initial stock reaching end of life"
   )
@@ -379,11 +372,11 @@ createParameters <- function(m, config, inputDir) {
   )
 
   p_shareRenHS <- shareRen(ltHs) %>%
-    select("hs", "region", "typ", "ttot2", "ttot", "value") %>%
-    toModelResolution(m)
+    select("hs", "region", "typ", "ttotIn", "ttotOut", "value") %>%
+    toModelResolution(m, ignoreDims = c("ttotIn", "ttotOut"))
   p_shareRenHS <- m$addParameter(
     name = "p_shareRenHS",
-    domain = c("hs", "region", "typ", "ttot2", "ttot"),
+    domain = c("hs", "region", "typ", "ttotIn", "ttotOut"),
     records = p_shareRenHS,
     description = "minimum share of renovation from the heating system reaching end of life"
   )
@@ -391,47 +384,50 @@ createParameters <- function(m, config, inputDir) {
   # assumption: average life time of initial stock of heating systems: 12 years
   standingLifeTimeHs <- 12
   p_shareRenHSinit <- shareRen(ltHs, standingLifeTime = standingLifeTimeHs) %>%
-    select("hs", "region", "typ", "ttot2", "ttot", "value") %>%
-    toModelResolution(m)
+    select("hs", "region", "typ", "ttotIn", "ttotOut", "value") %>%
+    toModelResolution(m, ignoreDims = c("ttotIn", "ttotOut"))
   p_shareRenHSinit <- m$addParameter(
     name = "p_shareRenHSinit",
-    domain = c("hs", "region", "typ", "ttot2", "ttot"),
+    domain = c("hs", "region", "typ", "ttotIn", "ttotOut"),
     records = p_shareRenHSinit,
     description = "minimum share of renovation from the heating system of initial stock reaching end of life"
   )
 
   # Only for reporting: Weibull distribution with high time resolution
-  timePeriodsFull <- expandSets(ttot2 = "ttot", .m = m) %>%
-    tidyr::crossing(ttot = seq(0, 60, 0.5)) %>%
-    mutate(ttot = .data$ttot2 + .data$ttot)
+  timePeriodsFull <- expandSets(ttotIn = "ttot", .m = m) %>%
+    tidyr::crossing(lt = seq(0, 60, 0.5)) %>%
+    mutate(ttotOut = .data$ttotIn + .data$lt) %>%
+    select(-"lt")
 
-  p_distrRenHSfull <- shareRen(ltHs, timePeriods = timePeriodsFull, returnDistr = TRUE) %>%
-    select("hs", "region", "typ", "ttot2", "ttot", "value")
-  p_distrRenHSfull <- m$addParameter(
-    name = "p_distrRenHSfull",
-    domain = c("hs", "region", "typ", "ttot2", "ttot"),
-    records = p_distrRenHSfull,
+  p_shareRenHSfull <- shareRen(ltHs, timePeriods = timePeriodsFull) %>%
+    select("hs", "region", "typ", "ttotIn", "ttotOut", "value") %>%
+    toModelResolution(m, ignoreDims = c("ttotIn", "ttotOut"))
+  p_shareRenHSfull <- m$addParameter(
+    name = "p_shareRenHSfull",
+    domain = c("hs", "region", "typ", "ttotIn", "ttotOut"),
+    records = p_shareRenHSfull,
     description = "distribution of hs renovation at high time resolution"
   )
 
   timePeriodsFullInit <- data.frame(
-    ttot2 = as.numeric(as.character(readSymbol(m, symbol = "tinit"))),
-    ttot = seq(0, 60, 0.5)
+    ttotIn = readSymbol(m, symbol = "tinit"),
+    lt = seq(0, 60, 0.5)
   ) %>%
-    mutate(ttot2 = .data$ttot2 - standingLifeTimeHs,
-           ttot = .data$ttot2 + .data$ttot)
+    mutate(ttotIn = .data$ttotIn - standingLifeTimeHs,
+           ttotOut = .data$ttotIn + .data$lt,
+           .keep = "none")
 
-  p_distrRenHSfullInit <- shareRen(
+  p_shareRenHSfullInit <- shareRen(
     ltHs,
     standingLifeTime = 0, # We already subtracted the standing lifetime, but still want the standing stock case
-    timePeriods = timePeriodsFullInit,
-    returnDistr = TRUE
+    timePeriods = timePeriodsFullInit
   ) %>%
-    select("hs", "region", "typ", "ttot2", "ttot", "value")
-  p_distrRenHSfullInit <- m$addParameter(
-    name = "p_distrRenHSfullInit",
-    domain = c("hs", "region", "typ", "ttot2", "ttot"),
-    records = p_distrRenHSfullInit,
+    select("hs", "region", "typ", "ttotIn", "ttotOut", "value") %>%
+    toModelResolution(m, ignoreDims = c("ttotIn", "ttotOut"))
+  p_shareRenHSfullInit <- m$addParameter(
+    name = "p_shareRenHSfullInit",
+    domain = c("hs", "region", "typ", "ttotIn", "ttotOut"),
+    records = p_shareRenHSfullInit,
     description = "distribution of hs renovation for initial stock at high time resolution"
   )
 

--- a/R/createSets.R
+++ b/R/createSets.R
@@ -46,7 +46,6 @@ createSets <- function(m, config) {
     records = ttotNum,
     description = "all modelling time steps"
   )
-  invisible(m$addAlias("ttot2", ttot))
 
   invisible(m$addSet(
     name = "tinit",

--- a/R/expandSets.R
+++ b/R/expandSets.R
@@ -18,7 +18,7 @@ expandSets <- function(..., .m = NULL) {
   setNames <- as.character(lapply(lst, function(l) .getSet(l, .m)$name))
 
   # convert elements of temporal dims to numeric
-  temporalSets <- c("ttot", "ttot2", "t", "thist")
+  temporalSets <- c("ttot", "tall", "ttot2", "t", "thist", "tinit", "tcalib")
   for (i in which(setNames %in% temporalSets)) {
     setElements[[i]] <- as.numeric(setElements[[i]])
   }

--- a/R/readSymbol.R
+++ b/R/readSymbol.R
@@ -64,7 +64,10 @@ readSymbol <- function(x, symbol = NULL, selectArea = TRUE,
   }
 
   # make temporal dimensions numeric
-  tDims <- intersect(colnames(data), c("ttot", "tall", "ttot2", "t"))
+  tDims <- intersect(
+    colnames(data),
+    c("ttot", "tall", "ttot2", "t", "thist", "tinit", "tcalib")
+  )
   for (tDim in tDims) {
     data[[tDim]] <- as.numeric(as.character(data[[tDim]]))
   }

--- a/R/readSymbol.R
+++ b/R/readSymbol.R
@@ -12,6 +12,8 @@
 readSymbol <- function(x, symbol = NULL, selectArea = TRUE,
                        stringAsFactor = TRUE) {
 
+  tDims <- c("ttot", "tall", "ttot2", "t", "thist", "tinit", "tcalib")
+
   # get gams Parameter, Variable or Set
   if (class(x)[1] == "Container") {
     if (length(symbol) != 1) {
@@ -45,6 +47,8 @@ readSymbol <- function(x, symbol = NULL, selectArea = TRUE,
       data[["element_text"]] <- NULL
       if (identical(colnames(data), "*")) {
         data <- getElement(data, "*")
+        # For one-dimensional time sets: Convert to numeric
+        if (symbol %in% tDims) data <- as.numeric(as.character(data))
       }
     }
   )
@@ -66,7 +70,7 @@ readSymbol <- function(x, symbol = NULL, selectArea = TRUE,
   # make temporal dimensions numeric
   tDims <- intersect(
     colnames(data),
-    c("ttot", "tall", "ttot2", "t", "thist", "tinit", "tcalib")
+    tDims
   )
   for (tDim in tDims) {
     data[[tDim]] <- as.numeric(as.character(data[[tDim]]))

--- a/R/toModelResolution.R
+++ b/R/toModelResolution.R
@@ -7,24 +7,24 @@
 #' @param x data.frame with temporal dimension
 #' @param m gams Container with sets as known dimensions
 #' @param value character, name of value column
-#' @param ignoreDims character, dimensions to be neither filtered nor extrapolated
+#' @param unfilteredDims character, dimensions to be neither filtered nor extrapolated
 #' @returns data.frame with temporal resolution according to model
 #'
 #' @author Robin Hasse
 #'
 #' @importFrom quitte interpolate_missing_periods_
 
-toModelResolution <- function(x, m, value = "value", ignoreDims = NULL) {
+toModelResolution <- function(x, m, value = "value", unfilteredDims = NULL) {
 
   if (!value %in% colnames(x)) {
     stop("Can't find the value column '", value, "'.")
   }
 
   # all temporal periods that should be interpolated
-  periodDims <- setdiff("ttot", ignoreDims)
+  periodDims <- setdiff("ttot", unfilteredDims)
 
   # drop lines with unknown dimension elements
-  for (f in setdiff(colnames(x), c(value, periodDims, ignoreDims))) {
+  for (f in setdiff(colnames(x), c(value, periodDims, unfilteredDims))) {
     x <- x[x[[f]] %in% m$getSymbols(f)[[1]]$getUELs(), ]
   }
 

--- a/R/toModelResolution.R
+++ b/R/toModelResolution.R
@@ -2,28 +2,29 @@
 #'
 #' Missing periods are interpolated linearly and extrapolated constantly,
 #' additional periods are removed and all other dimensions are filtered to the
-#' elements dined in the model sets.
+#' elements defined in the model sets.
 #'
 #' @param x data.frame with temporal dimension
 #' @param m gams Container with sets as known dimensions
 #' @param value character, name of value column
+#' @param ignoreDims character, dimensions to be neither filtered nor extrapolated
 #' @returns data.frame with temporal resolution according to model
 #'
 #' @author Robin Hasse
 #'
 #' @importFrom quitte interpolate_missing_periods_
 
-toModelResolution <- function(x, m, value = "value") {
+toModelResolution <- function(x, m, value = "value", ignoreDims = NULL) {
 
   if (!value %in% colnames(x)) {
     stop("Can't find the value column '", value, "'.")
   }
 
   # all temporal periods that should be interpolated
-  periodDims <- "ttot"
+  periodDims <- setdiff("ttot", ignoreDims)
 
   # drop lines with unknown dimension elements
-  for (f in setdiff(colnames(x), c(value, periodDims))) {
+  for (f in setdiff(colnames(x), c(value, periodDims, ignoreDims))) {
     x <- x[x[[f]] %in% m$getSymbols(f)[[1]]$getUELs(), ]
   }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <a href=''><img src='man/figures/logo_text_wide.svg' align='right' alt='logo' height=70 /></a> Building sector model with heterogeneous renovation and construction of the stock
 
-R package **brick**, version **0.8.8**
+R package **brick**, version **0.8.9**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/brick)](https://cran.r-project.org/package=brick) [![R build status](https://github.com/pik-piam/brick/workflows/check/badge.svg)](https://github.com/pik-piam/brick/actions) [![codecov](https://codecov.io/gh/pik-piam/brick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/brick) [![r-universe](https://pik-piam.r-universe.dev/badges/brick)](https://pik-piam.r-universe.dev/builds)
 
@@ -48,17 +48,15 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **brick** in publications use:
 
-Hasse R, Rosemann R (2025). "brick: Building sector model with heterogeneous renovation and construction of the stock." Version: 0.8.8, <https://github.com/pik-piam/brick>.
+Hasse R, Rosemann R (2025). "brick: Building sector model with heterogeneous renovation and construction of the stock - Version 0.8.9."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {brick: Building sector model with heterogeneous renovation and construction of the stock},
+  title = {brick: Building sector model with heterogeneous renovation and construction of the stock - Version 0.8.9},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2025-07-07},
+  date = {2025-07-14},
   year = {2025},
-  url = {https://github.com/pik-piam/brick},
-  note = {Version: 0.8.8},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {brick: Building sector model with heterogeneous renovation and construction of the stock - Version 0.8.9},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2025-07-14},
+  date = {2025-07-22},
   year = {2025},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {brick: Building sector model with heterogeneous renovation and construction of the stock - Version 0.8.9},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2025-07-22},
+  date = {2025-07-23},
   year = {2025},
 }
 ```

--- a/inst/gams/scripts/equations.gms
+++ b/inst/gams/scripts/equations.gms
@@ -335,15 +335,15 @@ $endif.earlydemolition
 q_buildingShellLifeTime(q,bs,vin,subs(reg,loc,typ,inc),ttot)$(    vinExists(ttot,vin)
                                                               and t(ttot))..
   sum(hs,
-    sum(ttot2$(    ttot2.val le ttot.val
-               !!and p_shareRenBS(reg,ttot2 + 1,ttot) < 1
-               and vinExists(ttot2,vin)),
-      p_dt(ttot2)
+    sum(ttotOut$(    ttotOut.val le ttot.val
+               !!and p_shareRenBS(reg,ttotOut + 1,ttot) < 1
+               and vinExists(ttotOut,vin)),
+      p_dt(ttotOut)
       * (
-        v_demolition(q,bs,hs,vin,subs,ttot2)
+        v_demolition(q,bs,hs,vin,subs,ttotOut)
         + sum(stateFull(bsr,hsr)$(    renAllowed(bs,hs,stateFull)
                                   and not sameas(bsr,"0")),
-            v_renovation(q,bs,hs,stateFull,vin,subs,ttot2)
+            v_renovation(q,bs,hs,stateFull,vin,subs,ttotOut)
           )
         )
     )
@@ -352,19 +352,19 @@ q_buildingShellLifeTime(q,bs,vin,subs(reg,loc,typ,inc),ttot)$(    vinExists(ttot
   v_slackRenBS(bs,vin,subs,ttot)
   +
   sum(hsr,
-    sum(ttot2$(    ttot2.val le ttot.val
-               !!and p_shareRenBS(reg,ttot2 + 1,ttot) < 1
-               and vinExists(ttot2,vin)),
-      p_shareRenBS(reg,ttot2,ttot)
+    sum(ttotIn$(    ttotIn.val le ttot.val
+               !!and p_shareRenBS(reg,ttotIn + 1,ttot) < 1
+               and vinExists(ttotIn,vin)),
+      p_shareRenBS(reg,ttotIn,ttot)
       * (
-        sum(hs(hsr), v_construction(q,bs,hs,subs,ttot2)) * p_dtVin(ttot2,vin)
+        sum(hs(hsr), v_construction(q,bs,hs,subs,ttotIn)) * p_dtVin(ttotIn,vin)
         + sum(state$renAllowed(state,bs,hsr),
-            v_renovation(q,state,bs,hsr,vin,subs,ttot2) * p_dt(ttot2)
+            v_renovation(q,state,bs,hsr,vin,subs,ttotIn) * p_dt(ttotIn)
           )
         )
       +
-      p_shareRenBSinit(reg,ttot2,ttot)
-      * sum(hs(hsr), v_stock(q,bs,hs,vin,subs,ttot2)$(tinit(ttot2)))
+      p_shareRenBSinit(reg,ttotIn,ttot)
+      * sum(hs(hsr), v_stock(q,bs,hs,vin,subs,ttotIn)$(tinit(ttotIn)))
     )
   )
 ;
@@ -374,15 +374,15 @@ q_buildingShellLifeTime(q,bs,vin,subs(reg,loc,typ,inc),ttot)$(    vinExists(ttot
 q_heatingSystemLifeTime(q,hs,vin,subs(reg,loc,typ,inc),ttot)$(    vinExists(ttot,vin)
                                                             and t(ttot))..
   sum(bs,
-    sum(ttot2$(    ttot2.val le ttot.val
-               !!and p_shareRenHS(hs,reg,typ,ttot2 + 1,ttot) < 1
-               and vinExists(ttot2,vin)),
-      p_dt(ttot2)
+    sum(ttotOut$(    ttotOut.val le ttot.val
+               !!and p_shareRenHS(hs,reg,typ,ttotOut + 1,ttot) < 1
+               and vinExists(ttotOut,vin)),
+      p_dt(ttotOut)
       * (
-        v_demolition(q,bs,hs,vin,subs,ttot2)
+        v_demolition(q,bs,hs,vin,subs,ttotOut)
         + sum(stateFull(bsr,hsr)$(    renAllowed(bs,hs,stateFull)
                                   and not sameas(hsr,"0")),
-            v_renovation(q,bs,hs,bsr,hsr,vin,subs,ttot2)
+            v_renovation(q,bs,hs,bsr,hsr,vin,subs,ttotOut)
         )
       )
     )
@@ -391,22 +391,22 @@ q_heatingSystemLifeTime(q,hs,vin,subs(reg,loc,typ,inc),ttot)$(    vinExists(ttot
   v_slackRenHS(hs,vin,subs,ttot)
   +
   sum(bsr,
-    sum(ttot2$(    ttot2.val le ttot.val
-               !!and p_shareRenHS(hs,reg,typ,ttot2 + 1,ttot) < 1
-               and vinExists(ttot2,vin)),
-      p_shareRenHS(hs,reg,typ,ttot2,ttot)
+    sum(ttotIn$(    ttotIn.val le ttot.val
+               !!and p_shareRenHS(hs,reg,typ,ttotIn + 1,ttot) < 1
+               and vinExists(ttotIn,vin)),
+      p_shareRenHS(hs,reg,typ,ttotIn,ttot)
       * (
         sum(bs(bsr),
-            v_construction(q,bs,hs,subs,ttot2))
-        * p_dtVin(ttot2,vin)
+            v_construction(q,bs,hs,subs,ttotIn))
+        * p_dtVin(ttotIn,vin)
         +
         sum(state$renAllowed(state,bsr,hs),
-            v_renovation(q,state,bsr,hs,vin,subs,ttot2))
-        * p_dt(ttot2)
+            v_renovation(q,state,bsr,hs,vin,subs,ttotIn))
+        * p_dt(ttotIn)
       )
       +
-      p_shareRenHSinit(hs,reg,typ,ttot2,ttot)
-      * sum(bs(bsr), v_stock(q,bs,hs,vin,subs,ttot2)$(tinit(ttot2)))
+      p_shareRenHSinit(hs,reg,typ,ttotIn,ttot)
+      * sum(bs(bsr), v_stock(q,bs,hs,vin,subs,ttotIn)$(tinit(ttotIn)))
     )
   )
 ;

--- a/inst/gams/scripts/sets.gms
+++ b/inst/gams/scripts/sets.gms
@@ -80,7 +80,7 @@ alias(hsr,hsr2,hsr3);
 alias(bs,bs2,bs3);
 alias(hs,hs2,hs3);
 alias(vin,vin2,vin3);
-alias(ttot,ttot2);
+alias(ttot,ttot2,ttotIn,ttotOut);
 alias(t,t2);
 
 

--- a/man/toModelResolution.Rd
+++ b/man/toModelResolution.Rd
@@ -4,7 +4,7 @@
 \alias{toModelResolution}
 \title{interpolate and filter to get model resolution}
 \usage{
-toModelResolution(x, m, value = "value", ignoreDims = NULL)
+toModelResolution(x, m, value = "value", unfilteredDims = NULL)
 }
 \arguments{
 \item{x}{data.frame with temporal dimension}
@@ -13,7 +13,7 @@ toModelResolution(x, m, value = "value", ignoreDims = NULL)
 
 \item{value}{character, name of value column}
 
-\item{ignoreDims}{character, dimensions to be neither filtered nor extrapolated}
+\item{unfilteredDims}{character, dimensions to be neither filtered nor extrapolated}
 }
 \value{
 data.frame with temporal resolution according to model

--- a/man/toModelResolution.Rd
+++ b/man/toModelResolution.Rd
@@ -4,7 +4,7 @@
 \alias{toModelResolution}
 \title{interpolate and filter to get model resolution}
 \usage{
-toModelResolution(x, m, value = "value")
+toModelResolution(x, m, value = "value", ignoreDims = NULL)
 }
 \arguments{
 \item{x}{data.frame with temporal dimension}
@@ -12,6 +12,8 @@ toModelResolution(x, m, value = "value")
 \item{m}{gams Container with sets as known dimensions}
 
 \item{value}{character, name of value column}
+
+\item{ignoreDims}{character, dimensions to be neither filtered nor extrapolated}
 }
 \value{
 data.frame with temporal resolution according to model
@@ -19,7 +21,7 @@ data.frame with temporal resolution according to model
 \description{
 Missing periods are interpolated linearly and extrapolated constantly,
 additional periods are removed and all other dimensions are filtered to the
-elements dined in the model sets.
+elements defined in the model sets.
 }
 \author{
 Robin Hasse


### PR DESCRIPTION
Save the distribution of heating system renovation in input.gdx with high time resolution.

This is (only) needed for reporting purposes in the lifetime and LCC/LCOH analysis.

In addition, I added more names of time dimensions to be converted to numeric in ```expandSets``` and ```readSymbol```. I don't think it makes a difference for ```readSymbol```, but for ```expandSets``` I think it can be useful.

In principle, it would also fit nicely to include the renaming of ttot2 -> ttotIn and ttot -> ttotOut in this PR, because in the R-code, this appears precisely in the context of the lifetime computations. I haven't done it yet, though, because it was quite some effort in ```reportbrick```, so I'm a bit undecided whether I want to invest the time.