### PR TITLE
Fix bug in plotSummary

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1826280'
+ValidationKey: '1847391'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,11 +4,13 @@ on:
   push:
     branches: [main, master]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master]
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'brick: Building sector model with heterogeneous renovation and construction
   of the stock'
-version: 0.9.0
-date-released: '2025-07-23'
+version: 0.9.1
+date-released: '2025-08-01'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of the stock
-Version: 0.9.0
-Date: 2025-07-23
+Version: 0.9.1
+Date: 2025-08-01
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/R/plotSummary.R
+++ b/R/plotSummary.R
@@ -28,6 +28,7 @@ plotSummary <- function(path, facet = "typ", showHistStock = FALSE,
   config <- readConfig(file.path(path, "config", "config_COMPILED.yaml"), readDirect = TRUE)
   endyear <- config[["endyear"]]
   seqRen <- isTRUE(config[["switches"]][["SEQUENTIALREN"]])
+  ignoreShell <- isTRUE(config[["ignoreShell"]])
 
 
 
@@ -70,9 +71,14 @@ plotSummary <- function(path, facet = "typ", showHistStock = FALSE,
     Demolition = "v_demolition"
   )
   vars <- if (seqRen) {
-    c(vars,
-      RenovationBS = "v_renovationBS",
-      RenovationHS = "v_renovationHS")
+    if (ignoreShell) {
+      c(vars,
+        RenovationHS = "v_renovationHS")
+    } else {
+      c(vars,
+        RenovationBS = "v_renovationBS",
+        RenovationHS = "v_renovationHS")
+    }
   } else {
     c(vars,
       Renovation = "v_renovation")
@@ -207,7 +213,10 @@ plotSummary <- function(path, facet = "typ", showHistStock = FALSE,
 
   # PLOT -----------------------------------------------------------------------
 
-  for (fillDim in c("bs", "hs", "vin")) {
+  # Don't create building shell plot if shell renovations are suppressed
+  fillDimensions <- if (ignoreShell) c("hs", "vin") else c("bs", "hs", "vin")
+
+  for (fillDim in fillDimensions) {
 
     pData <- do.call(bind_rows, lapply(names(data), function(v) {
       d <- data[[v]] %>%

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <a href=''><img src='man/figures/logo_text_wide.svg' align='right' alt='logo' height=70 /></a> Building sector model with heterogeneous renovation and construction of the stock
 
-R package **brick**, version **0.9.0**
+R package **brick**, version **0.9.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/brick)](https://cran.r-project.org/package=brick) [![R build status](https://github.com/pik-piam/brick/workflows/check/badge.svg)](https://github.com/pik-piam/brick/actions) [![codecov](https://codecov.io/gh/pik-piam/brick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/brick) [![r-universe](https://pik-piam.r-universe.dev/badges/brick)](https://pik-piam.r-universe.dev/builds)
 
@@ -48,17 +48,15 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **brick** in publications use:
 
-Hasse R, Rosemann R (2025). "brick: Building sector model with heterogeneous renovation and construction of the stock." Version: 0.9.0, <https://github.com/pik-piam/brick>.
+Hasse R, Rosemann R (2025). "brick: Building sector model with heterogeneous renovation and construction of the stock - Version 0.9.1."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {brick: Building sector model with heterogeneous renovation and construction of the stock - Version 0.8.9},
+  title = {brick: Building sector model with heterogeneous renovation and construction of the stock - Version 0.9.1},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2025-07-23},
+  date = {2025-08-01},
   year = {2025},
-  url = {https://github.com/pik-piam/brick},
-  note = {Version: 0.9.0},
 }
 ```


### PR DESCRIPTION
With sequential renovation and ignore shell, the renovationBS data for plotting is empty, leading to errors. This is now skipped when plotting.

I decided to implement it in such a way that the ```v_renovationBS``` variable is not used if both ignoreShell and sequential renovation are switched on and that the plot by building shell ("bs") is not created. The latter also holds for hierarchical renovation, but also there the building shell plot probably is rather pointless.

There would have been other options, e.g. by generally skipping empty data frames for example. I went for this one, because I found it clear and clean, but if you prefer another option, please let me know.