### PR TITLE
Small adjustments for createCalibrationTarget

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2116920'
+ValidationKey: '2117128'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ type: software
 title: 'brick: Building sector model with heterogeneous renovation and construction
   of the stock'
 version: 0.10.4
-date-released: '2025-09-24'
+date-released: '2025-09-26'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of the stock
 Version: 0.10.4
-Date: 2025-09-24
+Date: 2025-09-26
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/R/createCalibrationTarget.R
+++ b/R/createCalibrationTarget.R
@@ -128,18 +128,6 @@ createCalibrationTarget <- function(path,
 
 
 
-
-
-  # CONFIG ---------------------------------------------------------------------
-
-  cfgCalib <- readConfig(calibConfig)
-  cfgMatching <- readConfig(file.path(path, "config", "config_COMPILED.yaml"), readDirect = TRUE)
-
-  periodMap <- .buildPeriodMap(cfgCalib, cfgMatching)
-  regionMap <- .buildRegionMap(cfgCalib, cfgMatching)
-
-
-
   # READ MATCHING --------------------------------------------------------------
 
   matchingGdx <- file.path(path, "output.gdx")

--- a/R/createRunFolder.R
+++ b/R/createRunFolder.R
@@ -2,11 +2,11 @@
 #'
 #' Create a folder for the model to run in and copy required gams files there.
 #'
-#' @param path character vector, containing
+#' @param path character vector, containing the path(s) to the folder(s) to be created.
 #' @param config list with run configuration
-#' @param overwrite logical; Should exiting folders be overwritten?
-#' @param recursive logical; Should exiting folders be overwritten?
-#' @param showWarnings logical; Should exiting folders be overwritten?
+#' @param overwrite logical, should existing folders be overwritten?
+#' @param recursive logical, should elements of the path other than the last be created?
+#' @param showWarnings logical, should a warning on not created paths be shown?
 #'
 #' @author Robin Hasse
 #'

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {brick: Building sector model with heterogeneous renovation and construction of the stock - Version 0.10.4},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2025-09-24},
+  date = {2025-09-26},
   year = {2025},
 }
 ```

--- a/man/createRunFolder.Rd
+++ b/man/createRunFolder.Rd
@@ -13,15 +13,15 @@ createRunFolder(
 )
 }
 \arguments{
-\item{path}{character vector, containing}
+\item{path}{character vector, containing the path(s) to the folder(s) to be created.}
 
 \item{config}{list with run configuration}
 
-\item{overwrite}{logical; Should exiting folders be overwritten?}
+\item{overwrite}{logical, should existing folders be overwritten?}
 
-\item{recursive}{logical; Should exiting folders be overwritten?}
+\item{recursive}{logical, should elements of the path other than the last be created?}
 
-\item{showWarnings}{logical; Should exiting folders be overwritten?}
+\item{showWarnings}{logical, should a warning on not created paths be shown?}
 }
 \description{
 Create a folder for the model to run in and copy required gams files there.


### PR DESCRIPTION
## Purpose of this PR
Adjust the ```createCalibrationTarget``` function to current calibration configs.

## Implementation changes
- For aggregation in time: Aggregate to the calibration time periods (given by ```calibperiods```) in the calibration config rather than to overall time periods (```periods```). We only need calibration targets for the time periods we're calibrating on. 
- Currently, if the calibration config is passed as a path, the function fails, because this path becomes part of the ```title``` in the config used for the BRICK run started by ```createCalibrationTarget``` and therefore part of a file name. But the resulting file name seems to be not valid. Now for the title of the new config, only the file name and not the whole path (if a path is given) of the calibration config is used.