### PR TITLE
Fixes for the matching aggregation

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2179269'
+ValidationKey: '2199852'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'brick: Building sector model with heterogeneous renovation and construction
   of the stock'
-version: 0.10.7
-date-released: '2025-10-06'
+version: 0.10.8
+date-released: '2025-10-08'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of the stock
-Version: 0.10.7
-Date: 2025-10-06
+Version: 0.10.8
+Date: 2025-10-08
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/R/createCalibrationTarget.R
+++ b/R/createCalibrationTarget.R
@@ -47,11 +47,12 @@ createCalibrationTarget <- function(path,
   # build mapping between matching and calibration periods
   .buildPeriodMap <- function(cfgCalib, cfgMatching) {
     periods <- cfgCalib$calibperiods
+    startyear <- cfgCalib$startyear
 
     dt <- data.frame(ttotAgg = periods, dt = c(NA, diff(periods)))
 
     periodMap <- dt %>%
-      filter(!is.na(.data$dt)) %>%
+      filter(!is.na(.data$dt), .data$ttotAgg >= startyear) %>%
       group_by(.data$ttotAgg) %>%
       reframe(ttot = seq(to = .data$ttotAgg, length.out = .data$dt))
 
@@ -207,6 +208,7 @@ createCalibrationTarget <- function(path,
   cfgCalib[["switches"]][["CALIBRATIONMETHOD"]] <- NULL
   cfgCalib[["title"]] <- paste(basename(path), "for", basename(calibConfig), sep = "_")
   cfgCalib[["matchingRun"]] <- normalizePath(path)
+  cfgCalib[["periods"]] <- cfgCalib$calibperiods
 
   runPath <- initModel(config = cfgCalib,
                        outputFolder = outputFolder,

--- a/R/createParameters.R
+++ b/R/createParameters.R
@@ -547,14 +547,6 @@ createParameters <- function(m, config, inputDir) {
     ))
   }
 
-  if (identical(config[["switches"]][["RUNTYPE"]], "calibration")) {
-    invisible(m$addSet(
-      "tcalib",
-      records = periodFromConfig(config, "tcalib"),
-      description = "time steps considered by the calibration when minimising deviation from target trajectories"
-    ))
-  }
-
 
   ## discrete choice calibration =====
 

--- a/R/initModel.R
+++ b/R/initModel.R
@@ -184,6 +184,7 @@ initModel <- function(config = NULL,
     isDev <- as.character(is_dev_package("brick"))
     slurmScriptPath <- brick.file("clusterstart", "startScriptSlurm.R")
     logFilePath <- file.path(path, "log.txt")
+    loadMredgebuildings <- as.character(cfg[["switches"]][["RUNTYPE"]] == "matching")
 
     exitCode <- system(paste0("sbatch --job-name=",
                               title,
@@ -191,7 +192,8 @@ initModel <- function(config = NULL,
                               " --mail-type=END,FAIL",
                               " --comment=BRICK",
                               " --wrap=\"",
-                              paste("Rscript", slurmScriptPath, path, brickDir, isDev, runReporting),
+                              paste("Rscript", slurmScriptPath, path, brickDir, isDev,
+                                    loadMredgebuildings, runReporting),
                               "\" ",
                               slurmConfig))
     Sys.sleep(1)

--- a/R/periodFromConfig.R
+++ b/R/periodFromConfig.R
@@ -35,7 +35,7 @@ periodFromConfig <- function(config, periodType) {
     thist = setdiff(ttot, t),
     tinit = min(ttot),
     t0 = min(t),
-    tcalib = calibperiods,
+    tcalib = calibperiods[which(calibperiods >= startyear)],
     stop("unknown type of period: ", periodType)
   )
 }

--- a/R/startModel.R
+++ b/R/startModel.R
@@ -41,7 +41,8 @@ startModel <- function(path, runReporting = TRUE) {
     }
   }
 
-  if ("reweightMatching" %in% restart) {
+  if (cfg[["switches"]][["RUNTYPE"]] == "matching" &&
+        "reweightMatching" %in% restart) {
     reweightMatchingReferences(path)
   }
 
@@ -57,7 +58,7 @@ startModel <- function(path, runReporting = TRUE) {
   if (cfg[["switches"]][["RUNTYPE"]] == "calibration") {
     runCalibration(path,
                    parameters = cfg[["calibrationParameters"]],
-                   tcalib = cfg[["calibperiods"]],
+                   tcalib = periodFromConfig(cfg, "tcalib"),
                    gamsOptions = cfg[["gamsOptions"]],
                    switches = c(cfg[["switches"]],
                                 cfg[c("solverLP", "solverNLP", "solverQCP", "ignoreShell")]),
@@ -90,7 +91,9 @@ startModel <- function(path, runReporting = TRUE) {
 
     if (cfg[["switches"]][["RUNTYPE"]] == "matching") {
       plotRefDeviation(path)
-      plotMatchingComparison(path)
+      print(path)
+      print(normalizePath(path))
+      plotMatchingComparison(normalizePath(path))
       plotSummary(path, c("loc", "typ"))
     }
 

--- a/R/startModel.R
+++ b/R/startModel.R
@@ -91,8 +91,6 @@ startModel <- function(path, runReporting = TRUE) {
 
     if (cfg[["switches"]][["RUNTYPE"]] == "matching") {
       plotRefDeviation(path)
-      print(path)
-      print(normalizePath(path))
       plotMatchingComparison(normalizePath(path))
       plotSummary(path, c("loc", "typ"))
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <a href=''><img src='man/figures/logo_text_wide.svg' align='right' alt='logo' height=70 /></a> Building sector model with heterogeneous renovation and construction of the stock
 
-R package **brick**, version **0.10.7**
+R package **brick**, version **0.10.8**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/brick)](https://cran.r-project.org/package=brick) [![R build status](https://github.com/pik-piam/brick/workflows/check/badge.svg)](https://github.com/pik-piam/brick/actions) [![codecov](https://codecov.io/gh/pik-piam/brick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/brick) [![r-universe](https://pik-piam.r-universe.dev/badges/brick)](https://pik-piam.r-universe.dev/builds)
 
@@ -48,17 +48,15 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **brick** in publications use:
 
-Hasse R, Rosemann R (2025). "brick: Building sector model with heterogeneous renovation and construction of the stock." Version: 0.10.7, <https://github.com/pik-piam/brick>.
+Hasse R, Rosemann R (2025). "brick: Building sector model with heterogeneous renovation and construction of the stock - Version 0.10.8."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {brick: Building sector model with heterogeneous renovation and construction of the stock},
+  title = {brick: Building sector model with heterogeneous renovation and construction of the stock - Version 0.10.8},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2025-10-06},
+  date = {2025-10-08},
   year = {2025},
-  url = {https://github.com/pik-piam/brick},
-  note = {Version: 0.10.7},
 }
 ```

--- a/inst/clusterstart/startScriptSlurm.R
+++ b/inst/clusterstart/startScriptSlurm.R
@@ -26,8 +26,14 @@ if (sys.nframe() == 0L) {
     message(paste("This is a development run. Loading brick from local folder", brickDir))
   }
 
+  # Should mredgebuildings be loaded? (required in matching run)
+  loadMredgebuildings <- as.logical(argsCL[4])
+  if (isTRUE(loadMredgebuildings)) {
+    library("mredgebuildings")
+  }
+
   # Should the reporting be run?
-  runReporting <- as.logical(argsCL[4])
+  runReporting <- as.logical(argsCL[5])
 
   brick::startModel(path, runReporting = runReporting)
 }

--- a/inst/clusterstart/startScriptSlurm.R
+++ b/inst/clusterstart/startScriptSlurm.R
@@ -29,7 +29,7 @@ if (sys.nframe() == 0L) {
   # Should mredgebuildings be loaded? (required in matching run)
   loadMredgebuildings <- as.logical(argsCL[4])
   if (isTRUE(loadMredgebuildings)) {
-    library("mredgebuildings")
+    library("mredgebuildings") #nolint: undesirable_function_linter.
   }
 
   # Should the reporting be run?

--- a/inst/config/calibration.yaml
+++ b/inst/config/calibration.yaml
@@ -5,7 +5,7 @@ basedOn: "default.yaml"
 granularity: lowGran
 periods: [2000, 2005, 2010, 2015, 2020, 2025, 2030, 2035, 2040, 2045, 2050]
 startyear: 2005
-calibperiods: [2005, 2010]
+calibperiods: [2000, 2005, 2010]
 regionmapping: ["regionmappingEU27asOne.csv", "mredgebuildings"]
 regions: EUR
 ignoreShell: TRUE

--- a/inst/gams/scripts/bounds.gms
+++ b/inst/gams/scripts/bounds.gms
@@ -1,6 +1,6 @@
 *** fix variables for historic periods
 
-$ifthen.notMatching not "%RUNTYPE%" == "matching"
+$ifthenE.notMatching (sameas("%RUNTYPE%","scenario"))or(sameas("%RUNTYPE%","calibration"))
 
 v_stock.fx(qty,state,vin,subs,thist)$vinExists(thist,vin) = p_stockHist(qty,state,vin,subs,thist);
 v_construction.fx(qty,state,subs,thist)                                  = 0;
@@ -58,8 +58,15 @@ $endif.fixedBuildings
 *** renovation correction
 
 $ifthen.renCorrect "%RUNTYPE%" == "renCorrect"
-v_stock.fx(qty,bs,hs,vin,region,loc,typ,inc,tinit) = p_stock(qty,bs,hs,vin,region,loc,typ,inc,tinit);
+v_stock.fx(qty,bs,hs,vin,region,loc,typ,inc,thist) = p_stock(qty,bs,hs,vin,region,loc,typ,inc,thist);
 v_construction.fx(qty,bs,hs,region,loc,typ,inc,t) = p_construction(qty,bs,hs,region,loc,typ,inc,t);
+v_demolition.fx(qty,state,vin,subs,thist)$vinExists(thist,vin)           = 0;
+$ifthen.sequentialRen "%SEQUENTIALREN%" == "TRUE"
+v_renovationBS.fx(qty,state,bsr,vin,subs,thist)$vinExists(thist,vin) = 0;
+v_renovationHS.fx(qty,state,hsr,vin,subs,thist)$vinExists(thist,vin) = 0;
+$else.sequentialRen
+v_renovation.fx(qty,renAllowed,vin,subs,thist)$vinExists(thist,vin) = 0;
+$endif.sequentialRen
 $endif.renCorrect
 
 

--- a/inst/gams/scripts/declarations.gms
+++ b/inst/gams/scripts/declarations.gms
@@ -270,5 +270,7 @@ p_renovationBS(qty,bs,hs,bsr,vin,region,loc,typ,inc,ttot)   "target flow of buil
 p_renovationHS(qty,bs,hs,hsr,vin,region,loc,typ,inc,ttot)   "target flow of heating system replacement and untouched buildings [million m2/yr]"
 p_construction(qty,bs,hs,region,loc,typ,inc,ttot)           "target flow of new buildings [million m2/yr]"
 p_stock(qty, bs, hs, vin, region, loc, typ, inc, ttot)      "target stock of buildings [million m2]"
+p_renovationHSDiff(qty,bs,hs,hsr,vin,region,loc,typ,inc,ttot)   "difference of heating system replacement and untouched buildings [million m2/yr]"
+p_stockDiff(qty, bs, hs, vin, region, loc, typ, inc, ttot)      "difference in stock of buildings [million m2]"
 ;
 $endif.renCorrect

--- a/inst/gams/scripts/equations.gms
+++ b/inst/gams/scripts/equations.gms
@@ -980,7 +980,7 @@ q_renCorrectObj..
   )
   +
   sum((state,subs,t),
-    sqr(
+    p_dt(t) * sqr(
         v_construction("area",state,subs,t)
       - p_construction("area",state,subs,t)
     )
@@ -989,7 +989,7 @@ q_renCorrectObj..
 $ifthen.sequentialRen "%SEQUENTIALREN%" == "TRUE"
   sum((renAllowedBS(state,bsr),vin,subs,t)$(    not(sameas(bsr,"0"))
                                             and vinExists(t,vin)),
-    sqr(
+    p_dt(t) * sqr(
         v_renovationBS("area",renAllowedBS,vin,subs,t)
       - p_renovationBS("area",renAllowedBS,vin,subs,t)
     )
@@ -997,7 +997,7 @@ $ifthen.sequentialRen "%SEQUENTIALREN%" == "TRUE"
   +
   sum((renAllowedHS(state,hsr),vin,subs,t)$(    not(sameas(hsr,"0"))
                                             and vinExists(t,vin)),
-    sqr(
+    p_dt(t) * sqr(
         v_renovationHS("area",renAllowedHS,vin,subs,t)
       - p_renovationHS("area",renAllowedHS,vin,subs,t)
     )
@@ -1006,7 +1006,7 @@ $else.sequentialRen
   sum((ren(renAllowed(state,bsr,hsr)),vin,subs,t)$(not(    sameas(hsr,"0")
                                                        and sameas(bsr,"0"))
                                                    and vinExists(t,vin)),
-    sqr(
+    p_dt(t) * sqr(
         v_renovation("area",ren,vin,subs,t)
       - p_renovation("area",ren,vin,subs,t)
     )

--- a/inst/gams/scripts/output.gms
+++ b/inst/gams/scripts/output.gms
@@ -17,6 +17,12 @@ if(card(ErrStock) + card(ErrConstruction) + card(ErrRenovation) + card(ErrDemoli
   abort "Variable entries that should not exist are greater zero. abort.gdx written";
 );
 
+$ifThen.renCorrect "%RUNTYPE%" == "renCorrect"
+p_stockDiff("area",state,vin,subs,ttot) = v_stock.l("area",state,vin,subs,ttot) - p_stock("area",state,vin,subs,ttot);
+p_renovationHSDiff("area",renAllowedHS,vin,subs,t) =  v_renovationHS.l("area",renAllowedHS,vin,subs,t)
+                                                      - p_renovationHS("area",renAllowedHS,vin,subs,t);
+$endIf.renCorrect
+
 
 
 *** write results


### PR DESCRIPTION
## Purpose of this PR
Fix several bugs and issues in the matching aggregation and in particular in the correction run.

## Implementation changes
- Enable running the matching on the cluster by loading mredgebuildings and converting one path to absolute.
- Fix time period mismatch for calibration target creation: This was missing the initial time period (usually 2000).
- Remove code duplicate in createParameters.
- Use only the time periods to calibrate on in the matching aggregation.
- Enable to have multiple historic time periods in the calibration config when calling ```createCalibrationTarget```.
- Scale flow contributions in the minimization objective by length of time period.
- Fix historic stock on matching result and historic flows to zero.
- Add difference between uncorrected matching and correction to the gdx.
- Only apply reweightMatching as default restart option if this is a matching run.