### PR TITLE
Set renovation price sensitivity to 0.03

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2726899'
+ValidationKey: '2749278'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'brick: Building sector model with heterogeneous renovation and construction
   of the stock'
-version: 0.13.3
-date-released: '2026-02-19'
+version: 0.13.4
+date-released: '2026-03-05'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of the stock
-Version: 0.13.3
-Date: 2026-02-19
+Version: 0.13.4
+Date: 2026-03-05
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <a href=''><img src='man/figures/logo_text_wide.svg' align='right' alt='logo' height=70 /></a> Building sector model with heterogeneous renovation and construction of the stock
 
-R package **brick**, version **0.13.3**
+R package **brick**, version **0.13.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/brick)](https://cran.r-project.org/package=brick) [![R build status](https://github.com/pik-piam/brick/workflows/check/badge.svg)](https://github.com/pik-piam/brick/actions) [![codecov](https://codecov.io/gh/pik-piam/brick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/brick) [![r-universe](https://pik-piam.r-universe.dev/badges/brick)](https://pik-piam.r-universe.dev/builds)
 
@@ -48,15 +48,17 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **brick** in publications use:
 
-Hasse R, Rosemann R (2026). "brick: Building sector model with heterogeneous renovation and construction of the stock - Version 0.13.3."
+Hasse R, Rosemann R (2026). "brick: Building sector model with heterogeneous renovation and construction of the stock." Version: 0.13.4, <https://github.com/pik-piam/brick>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {brick: Building sector model with heterogeneous renovation and construction of the stock - Version 0.13.3},
+  title = {brick: Building sector model with heterogeneous renovation and construction of the stock},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2026-02-19},
+  date = {2026-03-05},
   year = {2026},
+  url = {https://github.com/pik-piam/brick},
+  note = {Version: 0.13.4},
 }
 ```

--- a/inst/config/default.yaml
+++ b/inst/config/default.yaml
@@ -223,10 +223,10 @@ identVinCharact: FALSE
 priceSens:
   bs:
     construction: 0.1
-    renovation: 0.04
+    renovation: 0.03
   hs:
     construction: 0.1
-    renovation: 0.04
+    renovation: 0.03
 
 ### Freeze Parameters ###
 # select parameters and freeze them to the value in a selected period


### PR DESCRIPTION
We decided to set the default price sensitivity to 0.03 for renovations, at least for the time-being, but apparently I only adapted this in my local configs so far and not in the ```default.yaml```.

This PR sets the price sensitivity to 0.03 for renovations in the ```default.yaml```.