### PR TITLE
Activate renAllowed, vinExists filter in calibration

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,5 @@
 ^.*CITATION.cff$
 ^codecov\.yml$
 ^inst/input$
+^\.claude$
+^_pkgdown\.yml$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2770875'
+ValidationKey: '2771685'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2749278'
+ValidationKey: '2770875'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
@@ -9,3 +9,4 @@ LogoHeightReadme: 70
 enforceVersionUpdate: no
 skipCoverage: no
 AutocreateCITATION: yes
+UsePkgDown: no

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'brick: Building sector model with heterogeneous renovation and construction
   of the stock'
-version: 0.13.4
-date-released: '2026-03-05'
+version: 0.13.5
+date-released: '2026-03-13'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ type: software
 title: 'brick: Building sector model with heterogeneous renovation and construction
   of the stock'
 version: 0.13.5
-date-released: '2026-03-13'
+date-released: '2026-03-19'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of the stock
-Version: 0.13.4
-Date: 2026-03-05
+Version: 0.13.5
+Date: 2026-03-13
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of the stock
 Version: 0.13.5
-Date: 2026-03-13
+Date: 2026-03-19
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/R/runCalibration.R
+++ b/R/runCalibration.R
@@ -198,6 +198,7 @@ runCalibrationLogit <- function(path,
 
     deviation <- .namedLapply(variables, function(var) {
       .computeDeviation(m, p_calibTarget[[var]], dims[[var]], tcalib, flow = var,
+                        renAllowed = renAllowed[[var]], vinExists = vinExists,
                         agg = switches[["AGGREGATEDIM"]], calibResolution = switches[["CALIBRESOLUTION"]])
     })
 

--- a/R/runCalibration.R
+++ b/R/runCalibration.R
@@ -197,8 +197,8 @@ runCalibrationLogit <- function(path,
     # READ IN BRICK RESULTS AND COMPUTE DEVIATION -------------------------------------------------
 
     deviation <- .namedLapply(variables, function(var) {
-      .computeDeviation(m, p_calibTarget[[var]], dims[[var]], tcalib, flow = var,
-                        renAllowed = renAllowed[[var]], vinExists = vinExists,
+      .computeDeviation(m, p_calibTarget[[var]], dims[[var]], tcalib,
+                        renAllowed = renAllowed[[var]], vinExists = vinExists, flow = var,
                         agg = switches[["AGGREGATEDIM"]], calibResolution = switches[["CALIBRESOLUTION"]])
     })
 
@@ -805,9 +805,9 @@ runCalibrationOptim <- function(path,
 #' @param target data frame of historical data
 #' @param dims character, dimensions of historic data and Brick results
 #' @param tcalib numeric, time steps to calibrate on
-#' @param flow character, either 'construction' or 'renovation'
 #' @param renAllowed data frame with allowed renovation transitions
 #' @param vinExists data frame with existing vintages for each time period
+#' @param flow character, either 'construction' or 'renovation'
 #' @param agg character, dimensions to aggregate Brick results and target data over
 #' @param calibResolution character, resolution of the calibration for renovation flows
 #'
@@ -816,9 +816,9 @@ runCalibrationOptim <- function(path,
 #' @importFrom dplyr %>% .data case_match case_when filter left_join mutate select
 #' @importFrom tidyr pivot_wider replace_na
 #'
-.computeDeviation <- function(m, target, dims, tcalib,
+.computeDeviation <- function(m, target, dims, tcalib, renAllowed, vinExists,
                               flow = c("construction", "renovation", "renovationBS", "renovationHS"),
-                              renAllowed = NULL, vinExists = NULL, agg = NULL, calibResolution = "full") {
+                              agg = NULL, calibResolution = "full") {
 
   flow <- match.arg(flow)
   eps <- 1E-14 # nolint: object_usage_linter.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {brick: Building sector model with heterogeneous renovation and construction of the stock},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2026-03-13},
+  date = {2026-03-19},
   year = {2026},
   url = {https://github.com/pik-piam/brick},
   note = {Version: 0.13.5},

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <a href=''><img src='man/figures/logo_text_wide.svg' align='right' alt='logo' height=70 /></a> Building sector model with heterogeneous renovation and construction of the stock
 
-R package **brick**, version **0.13.4**
+R package **brick**, version **0.13.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/brick)](https://cran.r-project.org/package=brick) [![R build status](https://github.com/pik-piam/brick/workflows/check/badge.svg)](https://github.com/pik-piam/brick/actions) [![codecov](https://codecov.io/gh/pik-piam/brick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/brick) [![r-universe](https://pik-piam.r-universe.dev/badges/brick)](https://pik-piam.r-universe.dev/builds)
 
@@ -48,7 +48,7 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **brick** in publications use:
 
-Hasse R, Rosemann R (2026). "brick: Building sector model with heterogeneous renovation and construction of the stock." Version: 0.13.4, <https://github.com/pik-piam/brick>.
+Hasse R, Rosemann R (2026). "brick: Building sector model with heterogeneous renovation and construction of the stock." Version: 0.13.5, <https://github.com/pik-piam/brick>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,9 +56,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {brick: Building sector model with heterogeneous renovation and construction of the stock},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2026-03-05},
+  date = {2026-03-13},
   year = {2026},
   url = {https://github.com/pik-piam/brick},
-  note = {Version: 0.13.4},
+  note = {Version: 0.13.5},
 }
 ```

--- a/man/dot-computeDeviation.Rd
+++ b/man/dot-computeDeviation.Rd
@@ -10,9 +10,9 @@ Then compute the adjustment term for the calibration \code{d}}
   target,
   dims,
   tcalib,
+  renAllowed,
+  vinExists,
   flow = c("construction", "renovation", "renovationBS", "renovationHS"),
-  renAllowed = NULL,
-  vinExists = NULL,
   agg = NULL,
   calibResolution = "full"
 )
@@ -26,11 +26,11 @@ Then compute the adjustment term for the calibration \code{d}}
 
 \item{tcalib}{numeric, time steps to calibrate on}
 
-\item{flow}{character, either 'construction' or 'renovation'}
-
 \item{renAllowed}{data frame with allowed renovation transitions}
 
 \item{vinExists}{data frame with existing vintages for each time period}
+
+\item{flow}{character, either 'construction' or 'renovation'}
 
 \item{agg}{character, dimensions to aggregate Brick results and target data over}
 


### PR DESCRIPTION
## Implementation changes
- A filter for renAllowed and vinExists was already present when computing the deviation, but was not active. This led to failure of the calibration based on identRepl.
- The filter was now activated by actually passing ```renAllowed``` and ```vinExists`` objects to the function.