### PR TITLE
Bugfix calibration and carbon price from config

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2874900'
+ValidationKey: '2899383'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'brick: Building sector model with heterogeneous renovation and construction
   of the stock'
-version: 0.14.0
-date-released: '2026-03-23'
+version: 0.14.1
+date-released: '2026-04-20'
 abstract: This building stock model represents residential and commercial buildings
   at customisable regional and temporal resolution. The building stock is quantified
   in floor area and distinguished by building type (SFH/MFH) and location (rural/urban).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: brick
 Title: Building sector model with heterogeneous renovation and construction of the stock
-Version: 0.14.0
-Date: 2026-03-23
+Version: 0.14.1
+Date: 2026-04-20
 Authors@R: c(
     person("Robin", "Hasse", , "robin.hasse@pik-potsdam.de",
            role = c("aut", "cre"),

--- a/R/addAssump.R
+++ b/R/addAssump.R
@@ -12,33 +12,26 @@
 #' @importFrom utils read.csv2
 #' @importFrom dplyr %>% .data mutate left_join select
 
-addAssump <- function(df, assumpFile, key = NULL, vinExists = NULL) {
+addAssump <- function(df, assumpFile, key = NULL) {
 
-  .extrapolate_missing_vin <- function(df, vin, vinExists) {
-    if (is.null(vinExists) || !"vin" %in% colnames(df)) {
+  # Extrapolate vintages: Fill NA values in df by extrapolating constantly from the last existing vintage
+  .extrapolateVintages <- function(df, vinWithVal) {
+    if (!"vin" %in% colnames(df)) {
       return(df)
     }
 
-    vintages <- df %>%
-      select("vin") %>%
-      unique()
-
-    vinMax <- vintages %>%
+    vinMax <- data.frame(vin = vinWithVal) %>%
       mutate(to = as.numeric(sub(".*(\\d{4})$", "\\1", as.character(.data$vin)))) %>%
       filter(.data$to == max(.data$to)) %>%
       dplyr::pull(var = "vin") %>%
       unique()
 
     df %>%
-      select(-"vin", -"value") %>%
-      tidyr::crossing(vin = vin) %>%
-      left_join(df, by = setdiff(colnames(df), "value")) %>%
-      right_join(vinExists, by = c("ttot", "vin")) %>%
       group_by(across(-all_of(c("vin", "value")))) %>%
       mutate(value = ifelse(
-        .data[["vin"]] %in% vintages$vin,
-        .data[["value"]],
-        .data[["value"]][.data[["vin"]] == vinMax]
+        .data$vin %in% vinWithVal,
+        .data$value,
+        .data$value[.data$vin == vinMax]
       )) %>%
       ungroup()
   }
@@ -72,17 +65,16 @@ addAssump <- function(df, assumpFile, key = NULL, vinExists = NULL) {
 
   df[["ttot"]] <- .asNumeric(df[["ttot"]], warn = FALSE)
   periods <- unique(df[["ttot"]])
-  vintages <- unique(df[["vin"]])
 
   if (!".chunk" %in% colnames(assump)) {
     # If the data contains no chunk column: Assume that this is the full data
 
+    vinAssump <- if ("vin" %in% colnames(assump)) unique(assump$vin) else NULL
+
     df <- assump %>%
       interpolate_missing_periods(ttot = periods, expand.values = TRUE) %>%
-      .extrapolate_missing_vin(vin = vintages, vinExists = vinExists) %>%
-      right_join(df, by = colnames(df))
-    
-    browser()
+      right_join(df, by = colnames(df)) %>%
+      .extrapolateVintages(vinWithVal = vinAssump)
 
     if (any(is.na(df$value))) {
       warning("Data on intangible costs is incomplete. First row with missing data: ",

--- a/R/addAssump.R
+++ b/R/addAssump.R
@@ -12,7 +12,36 @@
 #' @importFrom utils read.csv2
 #' @importFrom dplyr %>% .data mutate left_join select
 
-addAssump <- function(df, assumpFile, key = NULL) {
+addAssump <- function(df, assumpFile, key = NULL, vinExists = NULL) {
+
+  .extrapolate_missing_vin <- function(df, vin, vinExists) {
+    if (is.null(vinExists) || !"vin" %in% colnames(df)) {
+      return(df)
+    }
+
+    vintages <- df %>%
+      select("vin") %>%
+      unique()
+
+    vinMax <- vintages %>%
+      mutate(to = as.numeric(sub(".*(\\d{4})$", "\\1", as.character(.data$vin)))) %>%
+      filter(.data$to == max(.data$to)) %>%
+      dplyr::pull(var = "vin") %>%
+      unique()
+
+    df %>%
+      select(-"vin", -"value") %>%
+      tidyr::crossing(vin = vin) %>%
+      left_join(df, by = setdiff(colnames(df), "value")) %>%
+      right_join(vinExists, by = c("ttot", "vin")) %>%
+      group_by(across(-all_of(c("vin", "value")))) %>%
+      mutate(value = ifelse(
+        .data[["vin"]] %in% vintages$vin,
+        .data[["value"]],
+        .data[["value"]][.data[["vin"]] == vinMax]
+      )) %>%
+      ungroup()
+  }
 
   if (is.list(assumpFile)) {
     if (is.null(key)) {
@@ -27,6 +56,7 @@ addAssump <- function(df, assumpFile, key = NULL) {
   }
 
   assump <- read.csv(assumpFile, stringsAsFactors = TRUE, na.strings = "", comment.char = "#")
+  if ("bsr" %in% colnames(assump)) assump[["bsr"]] <- as.character(assump[["bsr"]])
   assump[["value"]] <- .asNumeric(assump[["value"]], warn = FALSE)
 
   if (!is.null(key)) {
@@ -42,13 +72,17 @@ addAssump <- function(df, assumpFile, key = NULL) {
 
   df[["ttot"]] <- .asNumeric(df[["ttot"]], warn = FALSE)
   periods <- unique(df[["ttot"]])
+  vintages <- unique(df[["vin"]])
 
   if (!".chunk" %in% colnames(assump)) {
     # If the data contains no chunk column: Assume that this is the full data
 
     df <- assump %>%
       interpolate_missing_periods(ttot = periods, expand.values = TRUE) %>%
+      .extrapolate_missing_vin(vin = vintages, vinExists = vinExists) %>%
       right_join(df, by = colnames(df))
+    
+    browser()
 
     if (any(is.na(df$value))) {
       warning("Data on intangible costs is incomplete. First row with missing data: ",

--- a/R/addAssump.R
+++ b/R/addAssump.R
@@ -2,6 +2,7 @@
 #'
 #' @param df data.frame for the cost of construction or renovation
 #' @param assumpFile character, file path to assumption file
+#' @param vinDimMap data frame with mapping for vintages to start and end years.
 #' @param key character, renovation asset, either \code{"BS"} (building
 #'   shell) or  \code{"HS"} heating system.
 #' @returns data frame with added intangible cost
@@ -12,16 +13,16 @@
 #' @importFrom utils read.csv2
 #' @importFrom dplyr %>% .data mutate left_join select
 
-addAssump <- function(df, assumpFile, key = NULL) {
+addAssump <- function(df, assumpFile, vinDimMap = NULL, key = NULL) {
 
   # Extrapolate vintages: Fill NA values in df by extrapolating constantly from the last existing vintage
-  .extrapolateVintages <- function(df, vinWithVal) {
-    if (!"vin" %in% colnames(df)) {
+  .extrapolateVintages <- function(df, vinWithVal, vinDimMap = NULL) {
+    if (!"vin" %in% colnames(df) || is.null(vinDimMap)) {
       return(df)
     }
 
     vinMax <- data.frame(vin = vinWithVal) %>%
-      mutate(to = as.numeric(sub(".*(\\d{4})$", "\\1", as.character(.data$vin)))) %>%
+      left_join(vinDimMap, by = "vin") %>%
       filter(.data$to == max(.data$to)) %>%
       dplyr::pull(var = "vin") %>%
       unique()
@@ -74,7 +75,7 @@ addAssump <- function(df, assumpFile, key = NULL) {
     df <- assump %>%
       interpolate_missing_periods(ttot = periods, expand.values = TRUE) %>%
       right_join(df, by = colnames(df)) %>%
-      .extrapolateVintages(vinWithVal = vinAssump)
+      .extrapolateVintages(vinWithVal = vinAssump, vinDimMap = vinDimMap)
 
     if (any(is.na(df$value))) {
       warning("Data on intangible costs is incomplete. First row with missing data: ",

--- a/R/createParameters.R
+++ b/R/createParameters.R
@@ -148,12 +148,12 @@ createParameters <- function(m, config, inputDir) {
                                          "loc", "typ", "inc", "ttot", .m = m) %>%
       .filter(readSymbol(m, "renAllowedBS"), vinExists) %>%
       mutate(cost = "intangible", .before = 1) %>%
-      addAssump(intangCostFiles[["ren"]], key = "BS")
+      addAssump(intangCostFiles[["ren"]], vinDimMap = vintages, key = "BS")
     p_specCostRenHS_intang <- expandSets("bs", "hs", "hsr", "vin", "region",
                                          "loc", "typ", "inc", "ttot", .m = m) %>%
       .filter(readSymbol(m, "renAllowedHS"), vinExists) %>%
       mutate(cost = "intangible", .before = 1) %>%
-      addAssump(intangCostFiles[["ren"]], key = "HS")
+      addAssump(intangCostFiles[["ren"]], vinDimMap = vintages, key = "HS")
 
     p_specCostRenBS <- rbind(p_specCostRenBS_tang, p_specCostRenBS_intang)
     p_specCostRenHS <- rbind(p_specCostRenHS_tang, p_specCostRenHS_intang)
@@ -210,11 +210,10 @@ createParameters <- function(m, config, inputDir) {
     carbonPrice <- carbonPrice %>%
       listToDf(split = "\\.") %>%
       toModelResolution(m)
-    p_carbonPrice <- carbonPrice %>%
-      right_join(p_carbonPrice,
-                 by = setdiff(names(carbonPrice), "value"),
-                 suffix = c("Config", "")) %>%
-      relocate("carrier", "ttot", "value") %>%
+    p_carbonPrice <- p_carbonPrice %>%
+      left_join(carbonPrice,
+                by = setdiff(names(carbonPrice), "value"),
+                suffix = c("", "Config")) %>%
       mutate(value = .data$value + replace_na(.data$valueConfig, 0),
              .keep = "unused")
   }

--- a/R/createParameters.R
+++ b/R/createParameters.R
@@ -120,7 +120,7 @@ createParameters <- function(m, config, inputDir) {
     .explicitZero()
   p_specCostRenBS_tang <- expandSets("bs", "hs", "bsr", "vin", "region",
                                      "loc", "typ", "inc", "ttot", .m = m) %>%
-    .filter(readSymbol(m, "renAllowedBS")) %>%
+    .filter(readSymbol(m, "renAllowedBS"), vinExists) %>%
     mutate(cost = "tangible", .before = 1) %>%
     left_join(p_specCostRenBS_tang,
               by = c("bs", "bsr", "vin", "region", "typ", "ttot"))
@@ -132,7 +132,7 @@ createParameters <- function(m, config, inputDir) {
     .explicitZero()
   p_specCostRenHS_tang <- expandSets("bs", "hs", "hsr", "vin", "region",
                                      "loc", "typ", "inc", "ttot", .m = m) %>%
-    .filter(readSymbol(m, "renAllowedHS")) %>%
+    .filter(readSymbol(m, "renAllowedHS"), vinExists) %>%
     mutate(cost = "tangible", .before = 1) %>%
     left_join(p_specCostRenHS_tang,
               by = c("bs", "hs", "hsr", "vin", "region", "typ", "ttot"))
@@ -146,12 +146,14 @@ createParameters <- function(m, config, inputDir) {
 
     p_specCostRenBS_intang <- expandSets("bs", "hs", "bsr", "vin", "region",
                                          "loc", "typ", "inc", "ttot", .m = m) %>%
+      .filter(readSymbol(m, "renAllowedBS"), vinExists) %>%
       mutate(cost = "intangible", .before = 1) %>%
-      addAssump(intangCostFiles[["ren"]], key = "BS", vinExists = vinExists)
+      addAssump(intangCostFiles[["ren"]], key = "BS")
     p_specCostRenHS_intang <- expandSets("bs", "hs", "hsr", "vin", "region",
                                          "loc", "typ", "inc", "ttot", .m = m) %>%
+      .filter(readSymbol(m, "renAllowedHS"), vinExists) %>%
       mutate(cost = "intangible", .before = 1) %>%
-      addAssump(intangCostFiles[["ren"]], key = "HS", vinExists = vinExists)
+      addAssump(intangCostFiles[["ren"]], key = "HS")
 
     p_specCostRenBS <- rbind(p_specCostRenBS_tang, p_specCostRenBS_intang)
     p_specCostRenHS <- rbind(p_specCostRenHS_tang, p_specCostRenHS_intang)
@@ -174,7 +176,7 @@ createParameters <- function(m, config, inputDir) {
     p_specCostRen_intang <- expandSets("bs", "hs", "bsr", "hsr", "vin", "region",
                                        "loc", "typ", "inc", "ttot", .m = m) %>%
       mutate(cost = "intangible", .before = 1) %>%
-      addAssump(intangCostFiles[["ren"]], vinExists = vinExists)
+      addAssump(intangCostFiles[["ren"]])
 
     p_specCostRen_tang <- full_join(p_specCostRenBS_tang, p_specCostRenHS_tang,
                                     by = c("cost", state, "vin", "region", "loc", "typ", "inc", "ttot"),

--- a/R/createParameters.R
+++ b/R/createParameters.R
@@ -212,6 +212,7 @@ createParameters <- function(m, config, inputDir) {
       right_join(p_carbonPrice,
                  by = setdiff(names(carbonPrice), "value"),
                  suffix = c("Config", "")) %>%
+      relocate("carrier", "ttot", "value") %>%
       mutate(value = .data$value + replace_na(.data$valueConfig, 0),
              .keep = "unused")
   }

--- a/R/createParameters.R
+++ b/R/createParameters.R
@@ -147,11 +147,11 @@ createParameters <- function(m, config, inputDir) {
     p_specCostRenBS_intang <- expandSets("bs", "hs", "bsr", "vin", "region",
                                          "loc", "typ", "inc", "ttot", .m = m) %>%
       mutate(cost = "intangible", .before = 1) %>%
-      addAssump(intangCostFiles[["ren"]], key = "BS")
+      addAssump(intangCostFiles[["ren"]], key = "BS", vinExists = vinExists)
     p_specCostRenHS_intang <- expandSets("bs", "hs", "hsr", "vin", "region",
                                          "loc", "typ", "inc", "ttot", .m = m) %>%
       mutate(cost = "intangible", .before = 1) %>%
-      addAssump(intangCostFiles[["ren"]], key = "HS")
+      addAssump(intangCostFiles[["ren"]], key = "HS", vinExists = vinExists)
 
     p_specCostRenBS <- rbind(p_specCostRenBS_tang, p_specCostRenBS_intang)
     p_specCostRenHS <- rbind(p_specCostRenHS_tang, p_specCostRenHS_intang)
@@ -174,7 +174,7 @@ createParameters <- function(m, config, inputDir) {
     p_specCostRen_intang <- expandSets("bs", "hs", "bsr", "hsr", "vin", "region",
                                        "loc", "typ", "inc", "ttot", .m = m) %>%
       mutate(cost = "intangible", .before = 1) %>%
-      addAssump(intangCostFiles[["ren"]])
+      addAssump(intangCostFiles[["ren"]], vinExists = vinExists)
 
     p_specCostRen_tang <- full_join(p_specCostRenBS_tang, p_specCostRenHS_tang,
                                     by = c("cost", state, "vin", "region", "loc", "typ", "inc", "ttot"),

--- a/R/runCalibration.R
+++ b/R/runCalibration.R
@@ -137,8 +137,10 @@ runCalibrationLogit <- function(path,
     renovationBS = "p_specCostRenBS",
     renovationHS = "p_specCostRenHS"
   )
-  xinit <- lapply(costSym[variables], function(symb) {
-    filter(readSymbol(mInput, symb), .data$cost == "intangible")
+  xinit <- .namedLapply(variables, function(var) {
+    readSymbol(mInput, costSym[[var]]) %>%
+      filter(.data$cost == "intangible") %>%
+      .filter(renAllowed[[var]], if (var != "construction") vinExists else NULL)
   })
 
   # Brick only runs as standard scenario run
@@ -146,7 +148,7 @@ runCalibrationLogit <- function(path,
 
   # Initialise optimization variable and optimization objective data frames
   optimVar <- .namedLapply(variables, function(var) {
-    .initOptimVar(mInput, tcalib, dims[[var]], renAllowed[[var]])
+    .initOptimVar(mInput, tcalib, dims[[var]], renAllowed[[var]], if (var != "construction") vinExists else NULL)
   })
   outerObjective <- .initOuterObjective(mInput)
 
@@ -432,7 +434,9 @@ runCalibrationOptim <- function(path,
     renovationHS = "p_specCostRenHS"
   )
   xinit <- .namedLapply(variables, function(var) {
-    filter(readSymbol(mInput, costSym[[var]]), .data$cost == "intangible")
+    readSymbol(mInput, costSym[[var]]) %>%
+      filter(.data$cost == "intangible") %>%
+      .filter(renAllowed[[var]], if (var != "construction") vinExists else NULL)
   })
 
   switchesScenRun <- switches
@@ -440,7 +444,7 @@ runCalibrationOptim <- function(path,
 
   # Initialise optimization variable and optimization objective data frames
   optimVar <- .namedLapply(variables, function(var) {
-    .initOptimVar(mInput, tcalib, dims[[var]], renAllowed[[var]])
+    .initOptimVar(mInput, tcalib, dims[[var]], renAllowed[[var]], if (var != "construction") vinExists else NULL)
   })
   outerObjective <- .initOuterObjective(mInput)
 
@@ -698,16 +702,17 @@ runCalibrationOptim <- function(path,
 #' @param tcalib numeric, calibration time periods
 #' @param dims character, dimensions to initialize the data with
 #' @param renAllowed data frame with allowed renovation transitions
+#' @param vinExists data frame with allowed vintage and time period combinations
 #'
 #' @returns data frame of desired dimension with x = 0 (column to contain the optimzation variable)
 #'   and xA = 0.
 #'
 #' @importFrom dplyr %>% .data filter mutate right_join
 #'
-.initOptimVar <- function(mInput, tcalib, dims, renAllowed) {
+.initOptimVar <- function(mInput, tcalib, dims, renAllowed, vinExists) {
   do.call(expandSets, c(as.list(dims), .m = mInput)) %>%
     filter(.data[["ttot"]] %in% tcalib) %>%
-    .filter(renAllowed) %>%
+    .filter(renAllowed, vinExists) %>%
     mutate(x = 0, xA = 0)
 }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <a href=''><img src='man/figures/logo_text_wide.svg' align='right' alt='logo' height=70 /></a> Building sector model with heterogeneous renovation and construction of the stock
 
-R package **brick**, version **0.14.0**
+R package **brick**, version **0.14.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/brick)](https://cran.r-project.org/package=brick) [![R build status](https://github.com/pik-piam/brick/workflows/check/badge.svg)](https://github.com/pik-piam/brick/actions) [![codecov](https://codecov.io/gh/pik-piam/brick/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/brick) [![r-universe](https://pik-piam.r-universe.dev/badges/brick)](https://pik-piam.r-universe.dev/builds)
 
@@ -48,17 +48,15 @@ In case of questions / problems please contact Robin Hasse <robin.hasse@pik-pots
 
 To cite package **brick** in publications use:
 
-Hasse R, Rosemann R (2026). "brick: Building sector model with heterogeneous renovation and construction of the stock." Version: 0.14.0, <https://github.com/pik-piam/brick>.
+Hasse R, Rosemann R (2026). "brick: Building sector model with heterogeneous renovation and construction of the stock - Version 0.14.1."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {brick: Building sector model with heterogeneous renovation and construction of the stock},
+  title = {brick: Building sector model with heterogeneous renovation and construction of the stock - Version 0.14.1},
   author = {Robin Hasse and Ricarda Rosemann},
-  date = {2026-03-23},
+  date = {2026-04-20},
   year = {2026},
-  url = {https://github.com/pik-piam/brick},
-  note = {Version: 0.14.0},
 }
 ```

--- a/inst/config/calibration.yaml
+++ b/inst/config/calibration.yaml
@@ -8,7 +8,7 @@ startyear: 2005
 calibperiods: [2005, 2010]
 regionmapping: ["regionmappingEU27as9.csv", "mredgebuildings"]
 regions: ["EWN", "ECS", "ESC", "ECE", "DEU", "ENC", "ESW", "FRA", "IRL"]
-matchingRun: 2025-12-13_fixedBuildings
+matchingRun: 2026-01-21_fixedBuildings_2
 ignoreShell: TRUE
 statusQuoPreference: 0
 reportingTemplate: lowGran_ignoreShell

--- a/man/addAssump.Rd
+++ b/man/addAssump.Rd
@@ -4,12 +4,14 @@
 \alias{addAssump}
 \title{Add assumed intangible costs}
 \usage{
-addAssump(df, assumpFile, key = NULL)
+addAssump(df, assumpFile, vinDimMap = NULL, key = NULL)
 }
 \arguments{
 \item{df}{data.frame for the cost of construction or renovation}
 
 \item{assumpFile}{character, file path to assumption file}
+
+\item{vinDimMap}{data frame with mapping for vintages to start and end years.}
 
 \item{key}{character, renovation asset, either \code{"BS"} (building
 shell) or  \code{"HS"} heating system.}

--- a/man/dot-initOptimVar.Rd
+++ b/man/dot-initOptimVar.Rd
@@ -4,7 +4,7 @@
 \alias{.initOptimVar}
 \title{Initialize the data frame for the optimization variables}
 \usage{
-.initOptimVar(mInput, tcalib, dims, renAllowed)
+.initOptimVar(mInput, tcalib, dims, renAllowed, vinExists)
 }
 \arguments{
 \item{mInput}{Gamstransfer container with the input data}
@@ -14,6 +14,8 @@
 \item{dims}{character, dimensions to initialize the data with}
 
 \item{renAllowed}{data frame with allowed renovation transitions}
+
+\item{vinExists}{data frame with allowed vintage and time period combinations}
 }
 \value{
 data frame of desired dimension with x = 0 (column to contain the optimzation variable)


### PR DESCRIPTION
## Purpose of this PR
- Make calibration runnable with ```fixedBuildings``` and later calibration time periods.
- Enable setting the carbon price in config by specifying ```ttot``` and ```value``` only.

## Implementation changes
- Filter for existing vintages consistently in ```runCalibration()```.
- Set the correct order for columns when writing ```p_carbonPrice``` in ```createParameters```. Formerly, this had the wrong order in case only ```ttot``` and ```value``` were specified, which caused Gams to ignore the carbon price.